### PR TITLE
API cleanup and bugfixes to get minimal functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = {text = "GPL-3.0"}
 requires-python = ">=3.8"
 dependencies = [
     "voluptuous",
-    "zigpy>=0.60.2",
+    "zigpy>=0.68.1",
     'async-timeout; python_version<"3.11"',
 ]
 

--- a/zigpy_espzb/api.py
+++ b/zigpy_espzb/api.py
@@ -215,7 +215,7 @@ COMMAND_SCHEMAS = {
         },
         {
             "extended_panid": t.EUI64,
-            "panid": t.uint16_t,
+            "panid": t.PanId,
             "channel": t.uint8_t,
         },
     ),
@@ -255,7 +255,7 @@ COMMAND_SCHEMAS = {
     ),
     CommandId.panid_get: (
         {},
-        {"panid": t.uint16_t},
+        {"panid": t.PanId},
         {},
     ),
     CommandId.panid_set: (
@@ -498,7 +498,7 @@ COMMAND_SCHEMAS = {
     ),
     CommandId.link_key_get: (
         {},
-        {"key": t.KeyData},
+        {"ieee": t.EUI64, "key": t.KeyData},
         {},
     ),
     CommandId.link_key_set: (
@@ -971,10 +971,10 @@ class Znsp:
 
         return rsp["status"]
 
-    async def set_permit_join(self, parameter: t.uint8_t):
+    async def set_permit_join(self, duration: t.uint8_t):
         rsp = await self.send_command(
-            CommandId.permit_join_set,
-            role=parameter,
+            CommandId.permit_joining,
+            duration=duration,
         )
 
         return rsp["status"]
@@ -1062,9 +1062,6 @@ class Znsp:
         else:
             raise RuntimeError("Failed to trigger a reset/crash")
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(2)
 
         LOGGER.debug("Reset complete")
-
-        # TODO: is this required to load any network settings?
-        await self.network_init()

--- a/zigpy_espzb/api.py
+++ b/zigpy_espzb/api.py
@@ -19,7 +19,13 @@ import zigpy.types as t
 from zigpy.zdo.types import SimpleDescriptor
 
 from zigpy_espzb.exception import APIException, CommandError, MismatchedResponseError
-from zigpy_espzb.types import Bytes, DeviceAddrMode, ZnspTransmitOptions, list_replace
+from zigpy_espzb.types import (
+    Bytes,
+    DeviceAddrMode,
+    ZnspTransmitOptions,
+    deserialize_dict,
+    list_replace,
+)
 import zigpy_espzb.uart
 
 LOGGER = logging.getLogger(__name__)
@@ -731,7 +737,7 @@ class Znsp:
                     break
 
         try:
-            params, rest = t.deserialize_dict(command.payload, rx_schema)
+            params, rest = deserialize_dict(command.payload, rx_schema)
         except Exception:
             LOGGER.warning("Failed to parse command %s", command, exc_info=True)
 

--- a/zigpy_espzb/api.py
+++ b/zigpy_espzb/api.py
@@ -88,7 +88,7 @@ class FormNetwork(t.Struct):
     nwk_cfg1: t.uint32_t
 
 
-class CommandId(t.uint16_t):
+class CommandId(t.enum16):
     networkinit = 0x0000
     start = 0x0001
     device_state = 0x0002

--- a/zigpy_espzb/api.py
+++ b/zigpy_espzb/api.py
@@ -687,7 +687,11 @@ class Znsp:
             LOGGER.debug("Unparsed data remains after frame: %s, %s", command, rest)
 
         LOGGER.debug(
-            "Received command %s%s (seq %d)", command.command_id, params, command.seq
+            "Received %s %s%s (seq %d)",
+            ("indication" if command.frame_type == FrameType.Indicate else "response"),
+            command.command_id,
+            params,
+            command.seq,
         )
 
         status = Status.SUCCESS

--- a/zigpy_espzb/api.py
+++ b/zigpy_espzb/api.py
@@ -811,6 +811,9 @@ class Znsp:
             ),
         )
 
+        # TODO: wait for the `form_network` indication as well?
+        await asyncio.sleep(2)
+
         return rsp["status"]
 
     async def leave_network(self) -> None:
@@ -818,6 +821,9 @@ class Znsp:
 
     async def start(self, autostart: bool) -> Status:
         rsp = await self.send_command(CommandId.start, autostart=t.uint8_t(autostart))
+
+        # TODO: wait for the `form_network` indication as well?
+        await asyncio.sleep(2)
 
         return rsp["status"]
 

--- a/zigpy_espzb/api.py
+++ b/zigpy_espzb/api.py
@@ -16,13 +16,7 @@ else:
 from zigpy.config import CONF_DEVICE_PATH
 import zigpy.types as t
 
-from zigpy_espzb.commands import (
-    COMMAND_SCHEMAS,
-    Command,
-    CommandId,
-    FormNetwork,
-    FrameType,
-)
+from zigpy_espzb.commands import COMMAND_SCHEMAS, Command, CommandId, FrameType
 from zigpy_espzb.exception import APIException, CommandError
 from zigpy_espzb.types import (
     Bytes,
@@ -309,13 +303,11 @@ class Znsp:
     ) -> None:
         rsp = await self.send_command(
             CommandId.form_network,
-            form_nwk=FormNetwork(
-                role=role,
-                install_code_policy=install_code_policy,
-                max_children=max_children,
-                ed_timeout=ed_timeout,
-                keep_alive=keep_alive,
-            ),
+            role=role,
+            install_code_policy=install_code_policy,
+            max_children=max_children,
+            ed_timeout=ed_timeout,
+            keep_alive=keep_alive,
         )
 
         # TODO: wait for the `form_network` indication as well?

--- a/zigpy_espzb/api.py
+++ b/zigpy_espzb/api.py
@@ -324,9 +324,6 @@ class Znsp:
         # TODO: wait for the `form_network` indication as well?
         await asyncio.sleep(2)
 
-    async def leave_network(self) -> None:
-        await self.send_command(commands.LeaveNetworkReq)
-
     async def start(self, autostart: bool) -> Status:
         await self.send_command(commands.StartReq(autostart=autostart))
 
@@ -532,7 +529,7 @@ class Znsp:
         await self.send_command(commands.SystemResetReq(), wait_for_response=False)
         await self._poll_until_running()
 
-    async def system_factory(self):
+    async def factory_reset(self):
         await self.send_command(commands.SystemFactoryReq(), wait_for_response=False)
         await self._poll_until_running()
 

--- a/zigpy_espzb/commands.py
+++ b/zigpy_espzb/commands.py
@@ -1,0 +1,832 @@
+"""Serial command schemas."""
+
+import zigpy.types as t
+
+from zigpy_espzb.types import (
+    Bytes,
+    DeviceType,
+    ExtendedAddrMode,
+    NetworkState,
+    SecurityMode,
+    ShiftedChannels,
+    Status,
+    TXStatus,
+)
+
+
+class CommandId(t.enum16):
+    network_init = 0x0000
+    start = 0x0001
+    network_state = 0x0002
+    stack_status_handler = 0x0003
+    form_network = 0x0004
+    permit_joining = 0x0005
+    join_network = 0x0006
+    leave_network = 0x0007
+    start_scan = 0x0008
+    scan_complete_handler = 0x0009
+    stop_scan = 0x000A
+    panid_get = 0x000B
+    panid_set = 0x000C
+    extpanid_get = 0x000D
+    extpanid_set = 0x000E
+    primary_channel_mask_get = 0x000F
+    primary_channel_mask_set = 0x0010
+    secondary_channel_mask_get = 0x0011
+    secondary_channel_mask_set = 0x0012
+    current_channel_get = 0x0013
+    current_channel_set = 0x0014
+    tx_power_get = 0x0015
+    tx_power_set = 0x0016
+    network_key_get = 0x0017
+    network_key_set = 0x0018
+    nwk_frame_counter_get = 0x0019
+    nwk_frame_counter_set = 0x001A
+    network_role_get = 0x001B
+    network_role_set = 0x001C
+    short_addr_get = 0x001D
+    short_addr_set = 0x001E
+    long_addr_get = 0x001F
+    long_addr_set = 0x0020
+    channel_masks_get = 0x0021
+    channel_masks_set = 0x0022
+    nwk_update_id_get = 0x0023
+    nwk_update_id_set = 0x0024
+    trust_center_address_get = 0x0025
+    trust_center_address_set = 0x0026
+    link_key_get = 0x0027
+    link_key_set = 0x0028
+    security_mode_get = 0x0029
+    security_mode_set = 0x002A
+    use_predefined_nwk_panid_set = 0x002B
+    short_to_ieee = 0x002C
+    ieee_to_short = 0x002D
+    add_endpoint = 0x0100
+    remove_endpoint = 0x0101
+    attribute_read = 0x0102
+    attribute_write = 0x0103
+    attribute_report = 0x0104
+    attribute_discover = 0x0105
+    aps_read = 0x0106
+    aps_write = 0x0107
+    report_config = 0x0108
+    bind_set = 0x0200
+    unbind_set = 0x0201
+    find_match = 0x0202
+    aps_data_request = 0x0300
+    aps_data_indication = 0x0301
+    aps_data_confirm = 0x0302
+
+
+class FrameType(t.enum4):
+    Request = 0
+    Response = 1
+    Indicate = 2
+
+
+class Command(t.Struct):
+    version: t.uint4_t
+    frame_type: FrameType
+    reserved: t.uint8_t
+
+    command_id: CommandId
+    seq: t.uint8_t
+    length: t.uint16_t
+    payload: Bytes
+
+
+class FormNetwork(t.Struct):
+    role: DeviceType
+    install_code_policy: t.Bool
+
+    # For coordinators/routers
+    max_children: t.uint8_t = t.StructField(
+        requires=lambda f: f.role in (DeviceType.ROUTER, DeviceType.COORDINATOR)
+    )
+
+    # For end devices
+    ed_timeout: t.uint8_t = t.StructField(
+        requires=lambda f: f.role == DeviceType.END_DEVICE
+    )
+    keep_alive: t.uint32_t = t.StructField(
+        requires=lambda f: f.role == DeviceType.END_DEVICE
+    )
+
+
+class NetworkInitReq(t.Struct):
+    pass
+
+
+class NetworkInitRsp(t.Struct):
+    status: Status
+
+
+class NetworkInitInd(t.Struct):
+    pass
+
+
+class StartReq(t.Struct):
+    autostart: t.Bool
+
+
+class StartRsp(t.Struct):
+    status: Status
+
+
+class StartInd(t.Struct):
+    pass
+
+
+class FormNetworkReq(t.Struct):
+    form_nwk: FormNetwork
+
+
+class FormNetworkRsp(t.Struct):
+    status: Status
+
+
+class FormNetworkInd(t.Struct):
+    extended_panid: t.EUI64
+    panid: t.PanId
+    channel: t.uint8_t
+
+
+class PermitJoiningReq(t.Struct):
+    duration: t.uint8_t
+
+
+class PermitJoiningRsp(t.Struct):
+    status: Status
+
+
+class PermitJoiningInd(t.Struct):
+    duration: t.uint8_t
+
+
+class LeaveNetworkReq(t.Struct):
+    pass
+
+
+class LeaveNetworkRsp(t.Struct):
+    status: Status
+
+
+class LeaveNetworkInd(t.Struct):
+    short_addr: t.NWK
+    device_addr: t.EUI64
+    rejoin: t.Bool
+
+
+class ExtpanidGetReq(t.Struct):
+    pass
+
+
+class ExtpanidGetRsp(t.Struct):
+    ieee: t.EUI64
+
+
+class ExtpanidGetInd(t.Struct):
+    pass
+
+
+class ExtpanidSetReq(t.Struct):
+    ieee: t.EUI64
+
+
+class ExtpanidSetRsp(t.Struct):
+    status: Status
+
+
+class ExtpanidSetInd(t.Struct):
+    pass
+
+
+class PanidGetReq(t.Struct):
+    pass
+
+
+class PanidGetRsp(t.Struct):
+    panid: t.PanId
+
+
+class PanidGetInd(t.Struct):
+    pass
+
+
+class PanidSetReq(t.Struct):
+    panid: t.PanId
+
+
+class PanidSetRsp(t.Struct):
+    status: Status
+
+
+class PanidSetInd(t.Struct):
+    pass
+
+
+class ShortAddrGetReq(t.Struct):
+    pass
+
+
+class ShortAddrGetRsp(t.Struct):
+    short_addr: t.NWK
+
+
+class ShortAddrGetInd(t.Struct):
+    pass
+
+
+class ShortAddrSetReq(t.Struct):
+    short_addr: t.NWK
+
+
+class ShortAddrSetRsp(t.Struct):
+    status: Status
+
+
+class ShortAddrSetInd(t.Struct):
+    pass
+
+
+class LongAddrGetReq(t.Struct):
+    pass
+
+
+class LongAddrGetRsp(t.Struct):
+    ieee: t.EUI64
+
+
+class LongAddrGetInd(t.Struct):
+    pass
+
+
+class LongAddrSetReq(t.Struct):
+    ieee: t.EUI64
+
+
+class LongAddrSetRsp(t.Struct):
+    status: Status
+
+
+class LongAddrSetInd(t.Struct):
+    pass
+
+
+class CurrentChannelGetReq(t.Struct):
+    pass
+
+
+class CurrentChannelGetRsp(t.Struct):
+    channel: t.uint8_t
+
+
+class CurrentChannelGetInd(t.Struct):
+    pass
+
+
+class CurrentChannelSetReq(t.Struct):
+    channel: t.uint8_t
+
+
+class CurrentChannelSetRsp(t.Struct):
+    status: Status
+
+
+class CurrentChannelSetInd(t.Struct):
+    pass
+
+
+class PrimaryChannelMaskGetReq(t.Struct):
+    pass
+
+
+class PrimaryChannelMaskGetRsp(t.Struct):
+    channel_mask: ShiftedChannels
+
+
+class PrimaryChannelMaskGetInd(t.Struct):
+    pass
+
+
+class PrimaryChannelMaskSetReq(t.Struct):
+    channel_mask: ShiftedChannels
+
+
+class PrimaryChannelMaskSetRsp(t.Struct):
+    status: Status
+
+
+class PrimaryChannelMaskSetInd(t.Struct):
+    pass
+
+
+class AddEndpointReq(t.Struct):
+    endpoint: t.uint8_t
+    profile_id: t.uint16_t
+    device_id: t.uint16_t
+    app_flags: t.uint8_t
+    input_cluster_count: t.uint8_t
+    output_cluster_count: t.uint8_t
+    input_cluster_list: t.List[t.uint16_t]
+    output_cluster_list: t.List[t.uint16_t]
+
+
+class AddEndpointRsp(t.Struct):
+    status: Status
+
+
+class AddEndpointInd(t.Struct):
+    pass
+
+
+class NetworkStateReq(t.Struct):
+    pass
+
+
+class NetworkStateRsp(t.Struct):
+    network_state: NetworkState
+
+
+class NetworkStateInd(t.Struct):
+    pass
+
+
+class StackStatusHandlerReq(t.Struct):
+    pass
+
+
+class StackStatusHandlerRsp(t.Struct):
+    network_state: t.uint8_t
+
+
+class StackStatusHandlerInd(t.Struct):
+    network_state: t.uint8_t
+
+
+class ApsDataRequestReq(t.Struct):
+    dst_addr: t.EUI64
+    dst_endpoint: t.uint8_t
+    src_endpoint: t.uint8_t
+    address_mode: t.uint8_t
+    profile_id: t.uint16_t
+    cluster_id: t.uint16_t
+    tx_options: t.uint8_t
+    use_alias: t.Bool
+    src_addr: t.EUI64
+    sequence: t.uint8_t
+    radius: t.uint8_t
+    asdu_length: t.uint32_t
+    asdu: Bytes
+
+
+class ApsDataRequestRsp(t.Struct):
+    status: Status
+
+
+class ApsDataRequestInd(t.Struct):
+    pass
+
+
+class ApsDataIndicationReq(t.Struct):
+    pass
+
+
+class ApsDataIndicationRsp(t.Struct):
+    network_state: NetworkState
+    dst_addr_mode: ExtendedAddrMode
+    dst_addr: t.EUI64
+    dst_ep: t.uint8_t
+    src_addr_mode: ExtendedAddrMode
+    src_addr: t.EUI64
+    src_ep: t.uint8_t
+    profile_id: t.uint16_t
+    cluster_id: t.uint16_t
+    indication_status: TXStatus
+    security_status: t.uint8_t
+    lqi: t.uint8_t
+    rx_time: t.uint32_t
+    asdu_length: t.uint32_t
+    asdu: Bytes
+
+
+class ApsDataIndicationInd(t.Struct):
+    network_state: NetworkState
+    dst_addr_mode: ExtendedAddrMode
+    dst_addr: t.EUI64
+    dst_ep: t.uint8_t
+    src_addr_mode: ExtendedAddrMode
+    src_addr: t.EUI64
+    src_ep: t.uint8_t
+    profile_id: t.uint16_t
+    cluster_id: t.uint16_t
+    indication_status: TXStatus
+    security_status: t.uint8_t
+    lqi: t.uint8_t
+    rx_time: t.uint32_t
+    asdu_length: t.uint32_t
+    asdu: Bytes
+
+
+class ApsDataConfirmReq(t.Struct):
+    pass
+
+
+class ApsDataConfirmRsp(t.Struct):
+    network_state: NetworkState
+    dst_addr_mode: ExtendedAddrMode
+    dst_addr: t.EUI64
+    dst_ep: t.uint8_t
+    src_ep: t.uint8_t
+    tx_time: t.uint32_t
+    request_id: t.uint8_t
+    confirm_status: TXStatus
+    asdu_length: t.uint32_t
+    asdu: Bytes
+
+
+class ApsDataConfirmInd(t.Struct):
+    network_state: NetworkState
+    dst_addr_mode: ExtendedAddrMode
+    dst_addr: t.EUI64
+    dst_ep: t.uint8_t
+    src_ep: t.uint8_t
+    tx_time: t.uint32_t
+    confirm_status: TXStatus
+    asdu_length: t.uint32_t
+    asdu: Bytes
+
+
+class NetworkKeyGetReq(t.Struct):
+    pass
+
+
+class NetworkKeyGetRsp(t.Struct):
+    nwk_key: t.KeyData
+
+
+class NetworkKeyGetInd(t.Struct):
+    pass
+
+
+class NetworkKeySetReq(t.Struct):
+    nwk_key: t.KeyData
+
+
+class NetworkKeySetRsp(t.Struct):
+    status: Status
+
+
+class NetworkKeySetInd(t.Struct):
+    pass
+
+
+class NwkFrameCounterGetReq(t.Struct):
+    pass
+
+
+class NwkFrameCounterGetRsp(t.Struct):
+    nwk_frame_counter: t.uint32_t
+
+
+class NwkFrameCounterGetInd(t.Struct):
+    pass
+
+
+class NwkFrameCounterSetReq(t.Struct):
+    nwk_frame_counter: t.uint32_t
+
+
+class NwkFrameCounterSetRsp(t.Struct):
+    status: Status
+
+
+class NwkFrameCounterSetInd(t.Struct):
+    pass
+
+
+class NetworkRoleGetReq(t.Struct):
+    pass
+
+
+class NetworkRoleGetRsp(t.Struct):
+    role: DeviceType
+
+
+class NetworkRoleGetInd(t.Struct):
+    pass
+
+
+class NetworkRoleSetReq(t.Struct):
+    role: DeviceType
+
+
+class NetworkRoleSetRsp(t.Struct):
+    status: Status
+
+
+class NetworkRoleSetInd(t.Struct):
+    pass
+
+
+class UsePredefinedNwkPanidSetReq(t.Struct):
+    predefined: t.Bool
+
+
+class UsePredefinedNwkPanidSetRsp(t.Struct):
+    status: Status
+
+
+class UsePredefinedNwkPanidSetInd(t.Struct):
+    pass
+
+
+class NwkUpdateIdGetReq(t.Struct):
+    pass
+
+
+class NwkUpdateIdGetRsp(t.Struct):
+    nwk_update_id: t.uint8_t
+
+
+class NwkUpdateIdGetInd(t.Struct):
+    pass
+
+
+class NwkUpdateIdSetReq(t.Struct):
+    nwk_update_id: t.uint8_t
+
+
+class NwkUpdateIdSetRsp(t.Struct):
+    status: Status
+
+
+class NwkUpdateIdSetInd(t.Struct):
+    pass
+
+
+class TrustCenterAddressGetReq(t.Struct):
+    pass
+
+
+class TrustCenterAddressGetRsp(t.Struct):
+    trust_center_addr: t.EUI64
+
+
+class TrustCenterAddressGetInd(t.Struct):
+    pass
+
+
+class TrustCenterAddressSetReq(t.Struct):
+    trust_center_addr: t.EUI64
+
+
+class TrustCenterAddressSetRsp(t.Struct):
+    status: Status
+
+
+class TrustCenterAddressSetInd(t.Struct):
+    pass
+
+
+class LinkKeyGetReq(t.Struct):
+    pass
+
+
+class LinkKeyGetRsp(t.Struct):
+    ieee: t.EUI64
+    key: t.KeyData
+
+
+class LinkKeyGetInd(t.Struct):
+    pass
+
+
+class LinkKeySetReq(t.Struct):
+    key: t.KeyData
+
+
+class LinkKeySetRsp(t.Struct):
+    status: Status
+
+
+class LinkKeySetInd(t.Struct):
+    pass
+
+
+class SecurityModeGetReq(t.Struct):
+    pass
+
+
+class SecurityModeGetRsp(t.Struct):
+    security_mode: SecurityMode
+
+
+class SecurityModeGetInd(t.Struct):
+    pass
+
+
+class SecurityModeSetReq(t.Struct):
+    security_mode: SecurityMode
+
+
+class SecurityModeSetRsp(t.Struct):
+    status: Status
+
+
+class SecurityModeSetInd(t.Struct):
+    pass
+
+
+COMMAND_SCHEMAS = {
+    CommandId.network_init: (
+        NetworkInitReq,
+        NetworkInitRsp,
+        NetworkInitInd,
+    ),
+    CommandId.start: (
+        StartReq,
+        StartRsp,
+        StartInd,
+    ),
+    CommandId.form_network: (
+        FormNetworkReq,
+        FormNetworkRsp,
+        FormNetworkInd,
+    ),
+    CommandId.permit_joining: (
+        PermitJoiningReq,
+        PermitJoiningRsp,
+        PermitJoiningInd,
+    ),
+    CommandId.leave_network: (
+        LeaveNetworkReq,
+        LeaveNetworkRsp,
+        LeaveNetworkInd,
+    ),
+    CommandId.extpanid_get: (
+        ExtpanidGetReq,
+        ExtpanidGetRsp,
+        ExtpanidGetInd,
+    ),
+    CommandId.extpanid_set: (
+        ExtpanidSetReq,
+        ExtpanidSetRsp,
+        ExtpanidSetInd,
+    ),
+    CommandId.panid_get: (
+        PanidGetReq,
+        PanidGetRsp,
+        PanidGetInd,
+    ),
+    CommandId.panid_set: (
+        PanidSetReq,
+        PanidSetRsp,
+        PanidSetInd,
+    ),
+    CommandId.short_addr_get: (
+        ShortAddrGetReq,
+        ShortAddrGetRsp,
+        ShortAddrGetInd,
+    ),
+    CommandId.short_addr_set: (
+        ShortAddrSetReq,
+        ShortAddrSetRsp,
+        ShortAddrSetInd,
+    ),
+    CommandId.long_addr_get: (
+        LongAddrGetReq,
+        LongAddrGetRsp,
+        LongAddrGetInd,
+    ),
+    CommandId.long_addr_set: (
+        LongAddrSetReq,
+        LongAddrSetRsp,
+        LongAddrSetInd,
+    ),
+    CommandId.current_channel_get: (
+        CurrentChannelGetReq,
+        CurrentChannelGetRsp,
+        CurrentChannelGetInd,
+    ),
+    CommandId.current_channel_set: (
+        CurrentChannelSetReq,
+        CurrentChannelSetRsp,
+        CurrentChannelSetInd,
+    ),
+    CommandId.primary_channel_mask_get: (
+        PrimaryChannelMaskGetReq,
+        PrimaryChannelMaskGetRsp,
+        PrimaryChannelMaskGetInd,
+    ),
+    CommandId.primary_channel_mask_set: (
+        PrimaryChannelMaskSetReq,
+        PrimaryChannelMaskSetRsp,
+        PrimaryChannelMaskSetInd,
+    ),
+    CommandId.add_endpoint: (
+        AddEndpointReq,
+        AddEndpointRsp,
+        AddEndpointInd,
+    ),
+    CommandId.network_state: (
+        NetworkStateReq,
+        NetworkStateRsp,
+        NetworkStateInd,
+    ),
+    CommandId.stack_status_handler: (
+        StackStatusHandlerReq,
+        StackStatusHandlerRsp,
+        StackStatusHandlerInd,
+    ),
+    CommandId.aps_data_request: (
+        ApsDataRequestReq,
+        ApsDataRequestRsp,
+        ApsDataRequestInd,
+    ),
+    CommandId.aps_data_indication: (
+        ApsDataIndicationReq,
+        ApsDataIndicationRsp,
+        ApsDataIndicationInd,
+    ),
+    CommandId.aps_data_confirm: (
+        ApsDataConfirmReq,
+        ApsDataConfirmRsp,
+        ApsDataConfirmInd,
+    ),
+    CommandId.network_key_get: (
+        NetworkKeyGetReq,
+        NetworkKeyGetRsp,
+        NetworkKeyGetInd,
+    ),
+    CommandId.network_key_set: (
+        NetworkKeySetReq,
+        NetworkKeySetRsp,
+        NetworkKeySetInd,
+    ),
+    CommandId.nwk_frame_counter_get: (
+        NwkFrameCounterGetReq,
+        NwkFrameCounterGetRsp,
+        NwkFrameCounterGetInd,
+    ),
+    CommandId.nwk_frame_counter_set: (
+        NwkFrameCounterSetReq,
+        NwkFrameCounterSetRsp,
+        NwkFrameCounterSetInd,
+    ),
+    CommandId.network_role_get: (
+        NetworkRoleGetReq,
+        NetworkRoleGetRsp,
+        NetworkRoleGetInd,
+    ),
+    CommandId.network_role_set: (
+        NetworkRoleSetReq,
+        NetworkRoleSetRsp,
+        NetworkRoleSetInd,
+    ),
+    CommandId.use_predefined_nwk_panid_set: (
+        UsePredefinedNwkPanidSetReq,
+        UsePredefinedNwkPanidSetRsp,
+        UsePredefinedNwkPanidSetInd,
+    ),
+    CommandId.nwk_update_id_get: (
+        NwkUpdateIdGetReq,
+        NwkUpdateIdGetRsp,
+        NwkUpdateIdGetInd,
+    ),
+    CommandId.nwk_update_id_set: (
+        NwkUpdateIdSetReq,
+        NwkUpdateIdSetRsp,
+        NwkUpdateIdSetInd,
+    ),
+    CommandId.trust_center_address_get: (
+        TrustCenterAddressGetReq,
+        TrustCenterAddressGetRsp,
+        TrustCenterAddressGetInd,
+    ),
+    CommandId.trust_center_address_set: (
+        TrustCenterAddressSetReq,
+        TrustCenterAddressSetRsp,
+        TrustCenterAddressSetInd,
+    ),
+    CommandId.link_key_get: (
+        LinkKeyGetReq,
+        LinkKeyGetRsp,
+        LinkKeyGetInd,
+    ),
+    CommandId.link_key_set: (
+        LinkKeySetReq,
+        LinkKeySetRsp,
+        LinkKeySetInd,
+    ),
+    CommandId.security_mode_get: (
+        SecurityModeGetReq,
+        SecurityModeGetRsp,
+        SecurityModeGetInd,
+    ),
+    CommandId.security_mode_set: (
+        SecurityModeSetReq,
+        SecurityModeSetRsp,
+        SecurityModeSetInd,
+    ),
+}

--- a/zigpy_espzb/commands.py
+++ b/zigpy_espzb/commands.py
@@ -512,35 +512,46 @@ class SecurityModeSetReq(BaseCommand):
 class SecurityModeSetRsp(BaseCommand):
     status: Status
 
+
 class SystemResetReq(BaseCommand):
     pass
+
 
 class SystemResetRsp(BaseCommand):
     status: Status
 
+
 class SystemFactoryReq(BaseCommand):
     pass
+
 
 class SystemFactoryRsp(BaseCommand):
     status: Status
 
+
 class SystemFirmwareReq(BaseCommand):
     pass
+
 
 class SystemFirmwareRsp(BaseCommand):
     firmware_version: FirmwareVersion
 
+
 class SystemModelReq(BaseCommand):
     pass
+
 
 class SystemModelRsp(BaseCommand):
     payload: t.CharacterString
 
+
 class SystemManufacturerReq(BaseCommand):
     pass
 
+
 class SystemManufacturerRsp(BaseCommand):
     payload: t.CharacterString
+
 
 COMMAND_SCHEMAS = {
     CommandId.network_init: (

--- a/zigpy_espzb/commands.py
+++ b/zigpy_espzb/commands.py
@@ -6,6 +6,7 @@ from zigpy_espzb.types import (
     Bytes,
     DeviceType,
     ExtendedAddrMode,
+    FirmwareVersion,
     NetworkState,
     SecurityMode,
     ShiftedChannels,
@@ -77,6 +78,11 @@ class CommandId(t.enum16):
     aps_data_request = 0x0300
     aps_data_indication = 0x0301
     aps_data_confirm = 0x0302
+    system_reset = 0x0400
+    system_factory = 0x0401
+    system_firmware = 0x0402
+    system_model = 0x0403
+    system_manufacturer = 0x0404
 
 
 class FrameType(t.enum4):
@@ -506,6 +512,35 @@ class SecurityModeSetReq(BaseCommand):
 class SecurityModeSetRsp(BaseCommand):
     status: Status
 
+class SystemResetReq(BaseCommand):
+    pass
+
+class SystemResetRsp(BaseCommand):
+    status: Status
+
+class SystemFactoryReq(BaseCommand):
+    pass
+
+class SystemFactoryRsp(BaseCommand):
+    status: Status
+
+class SystemFirmwareReq(BaseCommand):
+    pass
+
+class SystemFirmwareRsp(BaseCommand):
+    firmware_version: FirmwareVersion
+
+class SystemModelReq(BaseCommand):
+    pass
+
+class SystemModelRsp(BaseCommand):
+    payload: t.CharacterString
+
+class SystemManufacturerReq(BaseCommand):
+    pass
+
+class SystemManufacturerRsp(BaseCommand):
+    payload: t.CharacterString
 
 COMMAND_SCHEMAS = {
     CommandId.network_init: (
@@ -696,6 +731,31 @@ COMMAND_SCHEMAS = {
     CommandId.security_mode_set: (
         SecurityModeSetReq,
         SecurityModeSetRsp,
+        None,
+    ),
+    CommandId.system_reset: (
+        SystemResetReq,
+        SystemResetRsp,
+        None,
+    ),
+    CommandId.system_factory: (
+        SystemFactoryReq,
+        SystemFactoryRsp,
+        None,
+    ),
+    CommandId.system_firmware: (
+        SystemFirmwareReq,
+        SystemFirmwareRsp,
+        None,
+    ),
+    CommandId.system_model: (
+        SystemModelReq,
+        SystemModelRsp,
+        None,
+    ),
+    CommandId.system_manufacturer: (
+        SystemManufacturerReq,
+        SystemManufacturerRsp,
         None,
     ),
 }

--- a/zigpy_espzb/commands.py
+++ b/zigpy_espzb/commands.py
@@ -10,6 +10,7 @@ from zigpy_espzb.types import (
     SecurityMode,
     ShiftedChannels,
     Status,
+    TransmitOptions,
     TXStatus,
 )
 
@@ -304,13 +305,13 @@ class ApsDataRequestReq(BaseCommand):
     dst_addr: t.EUI64
     dst_endpoint: t.uint8_t
     src_endpoint: t.uint8_t
-    address_mode: t.uint8_t
+    address_mode: ExtendedAddrMode
     profile_id: t.uint16_t
     cluster_id: t.uint16_t
-    tx_options: t.uint8_t
+    tx_options: TransmitOptions
     use_alias: t.Bool
-    src_addr: t.EUI64
-    sequence: t.uint8_t
+    alias_src_addr: t.EUI64
+    alias_seq_num: t.uint8_t
     radius: t.uint8_t
     asdu_length: t.uint32_t
     asdu: Bytes

--- a/zigpy_espzb/commands.py
+++ b/zigpy_espzb/commands.py
@@ -84,7 +84,7 @@ class FrameType(t.enum4):
     Indicate = 2
 
 
-class Command(t.Struct):
+class CommandFrame(t.Struct):
     version: t.uint4_t
     frame_type: FrameType
     reserved: t.uint8_t
@@ -95,31 +95,35 @@ class Command(t.Struct):
     payload: Bytes
 
 
-class NetworkInitReq(t.Struct):
+class BaseCommand(t.Struct):
     pass
 
 
-class NetworkInitRsp(t.Struct):
+class NetworkInitReq(BaseCommand):
+    pass
+
+
+class NetworkInitRsp(BaseCommand):
     status: Status
 
 
-class NetworkInitInd(t.Struct):
+class NetworkInitInd(BaseCommand):
     pass
 
 
-class StartReq(t.Struct):
+class StartReq(BaseCommand):
     autostart: t.Bool
 
 
-class StartRsp(t.Struct):
+class StartRsp(BaseCommand):
     status: Status
 
 
-class StartInd(t.Struct):
+class StartInd(BaseCommand):
     pass
 
 
-class FormNetworkReq(t.Struct):
+class FormNetworkReq(BaseCommand):
     role: DeviceType
     install_code_policy: t.Bool
 
@@ -137,187 +141,187 @@ class FormNetworkReq(t.Struct):
     )
 
 
-class FormNetworkRsp(t.Struct):
+class FormNetworkRsp(BaseCommand):
     status: Status
 
 
-class FormNetworkInd(t.Struct):
+class FormNetworkInd(BaseCommand):
     extended_panid: t.EUI64
     panid: t.PanId
     channel: t.uint8_t
 
 
-class PermitJoiningReq(t.Struct):
+class PermitJoiningReq(BaseCommand):
     duration: t.uint8_t
 
 
-class PermitJoiningRsp(t.Struct):
+class PermitJoiningRsp(BaseCommand):
     status: Status
 
 
-class PermitJoiningInd(t.Struct):
+class PermitJoiningInd(BaseCommand):
     duration: t.uint8_t
 
 
-class LeaveNetworkReq(t.Struct):
+class LeaveNetworkReq(BaseCommand):
     pass
 
 
-class LeaveNetworkRsp(t.Struct):
+class LeaveNetworkRsp(BaseCommand):
     status: Status
 
 
-class LeaveNetworkInd(t.Struct):
+class LeaveNetworkInd(BaseCommand):
     short_addr: t.NWK
     device_addr: t.EUI64
     rejoin: t.Bool
 
 
-class ExtpanidGetReq(t.Struct):
+class ExtpanidGetReq(BaseCommand):
     pass
 
 
-class ExtpanidGetRsp(t.Struct):
+class ExtpanidGetRsp(BaseCommand):
     ieee: t.EUI64
 
 
-class ExtpanidGetInd(t.Struct):
+class ExtpanidGetInd(BaseCommand):
     pass
 
 
-class ExtpanidSetReq(t.Struct):
+class ExtpanidSetReq(BaseCommand):
     ieee: t.EUI64
 
 
-class ExtpanidSetRsp(t.Struct):
+class ExtpanidSetRsp(BaseCommand):
     status: Status
 
 
-class ExtpanidSetInd(t.Struct):
+class ExtpanidSetInd(BaseCommand):
     pass
 
 
-class PanidGetReq(t.Struct):
+class PanidGetReq(BaseCommand):
     pass
 
 
-class PanidGetRsp(t.Struct):
+class PanidGetRsp(BaseCommand):
     panid: t.PanId
 
 
-class PanidGetInd(t.Struct):
+class PanidGetInd(BaseCommand):
     pass
 
 
-class PanidSetReq(t.Struct):
+class PanidSetReq(BaseCommand):
     panid: t.PanId
 
 
-class PanidSetRsp(t.Struct):
+class PanidSetRsp(BaseCommand):
     status: Status
 
 
-class PanidSetInd(t.Struct):
+class PanidSetInd(BaseCommand):
     pass
 
 
-class ShortAddrGetReq(t.Struct):
+class ShortAddrGetReq(BaseCommand):
     pass
 
 
-class ShortAddrGetRsp(t.Struct):
+class ShortAddrGetRsp(BaseCommand):
     short_addr: t.NWK
 
 
-class ShortAddrGetInd(t.Struct):
+class ShortAddrGetInd(BaseCommand):
     pass
 
 
-class ShortAddrSetReq(t.Struct):
+class ShortAddrSetReq(BaseCommand):
     short_addr: t.NWK
 
 
-class ShortAddrSetRsp(t.Struct):
+class ShortAddrSetRsp(BaseCommand):
     status: Status
 
 
-class ShortAddrSetInd(t.Struct):
+class ShortAddrSetInd(BaseCommand):
     pass
 
 
-class LongAddrGetReq(t.Struct):
+class LongAddrGetReq(BaseCommand):
     pass
 
 
-class LongAddrGetRsp(t.Struct):
+class LongAddrGetRsp(BaseCommand):
     ieee: t.EUI64
 
 
-class LongAddrGetInd(t.Struct):
+class LongAddrGetInd(BaseCommand):
     pass
 
 
-class LongAddrSetReq(t.Struct):
+class LongAddrSetReq(BaseCommand):
     ieee: t.EUI64
 
 
-class LongAddrSetRsp(t.Struct):
+class LongAddrSetRsp(BaseCommand):
     status: Status
 
 
-class LongAddrSetInd(t.Struct):
+class LongAddrSetInd(BaseCommand):
     pass
 
 
-class CurrentChannelGetReq(t.Struct):
+class CurrentChannelGetReq(BaseCommand):
     pass
 
 
-class CurrentChannelGetRsp(t.Struct):
+class CurrentChannelGetRsp(BaseCommand):
     channel: t.uint8_t
 
 
-class CurrentChannelGetInd(t.Struct):
+class CurrentChannelGetInd(BaseCommand):
     pass
 
 
-class CurrentChannelSetReq(t.Struct):
+class CurrentChannelSetReq(BaseCommand):
     channel: t.uint8_t
 
 
-class CurrentChannelSetRsp(t.Struct):
+class CurrentChannelSetRsp(BaseCommand):
     status: Status
 
 
-class CurrentChannelSetInd(t.Struct):
+class CurrentChannelSetInd(BaseCommand):
     pass
 
 
-class PrimaryChannelMaskGetReq(t.Struct):
+class PrimaryChannelMaskGetReq(BaseCommand):
     pass
 
 
-class PrimaryChannelMaskGetRsp(t.Struct):
+class PrimaryChannelMaskGetRsp(BaseCommand):
     channel_mask: ShiftedChannels
 
 
-class PrimaryChannelMaskGetInd(t.Struct):
+class PrimaryChannelMaskGetInd(BaseCommand):
     pass
 
 
-class PrimaryChannelMaskSetReq(t.Struct):
+class PrimaryChannelMaskSetReq(BaseCommand):
     channel_mask: ShiftedChannels
 
 
-class PrimaryChannelMaskSetRsp(t.Struct):
+class PrimaryChannelMaskSetRsp(BaseCommand):
     status: Status
 
 
-class PrimaryChannelMaskSetInd(t.Struct):
+class PrimaryChannelMaskSetInd(BaseCommand):
     pass
 
 
-class AddEndpointReq(t.Struct):
+class AddEndpointReq(BaseCommand):
     endpoint: t.uint8_t
     profile_id: t.uint16_t
     device_id: t.uint16_t
@@ -328,39 +332,39 @@ class AddEndpointReq(t.Struct):
     output_cluster_list: t.List[t.uint16_t]
 
 
-class AddEndpointRsp(t.Struct):
+class AddEndpointRsp(BaseCommand):
     status: Status
 
 
-class AddEndpointInd(t.Struct):
+class AddEndpointInd(BaseCommand):
     pass
 
 
-class NetworkStateReq(t.Struct):
+class NetworkStateReq(BaseCommand):
     pass
 
 
-class NetworkStateRsp(t.Struct):
+class NetworkStateRsp(BaseCommand):
     network_state: NetworkState
 
 
-class NetworkStateInd(t.Struct):
+class NetworkStateInd(BaseCommand):
     pass
 
 
-class StackStatusHandlerReq(t.Struct):
+class StackStatusHandlerReq(BaseCommand):
     pass
 
 
-class StackStatusHandlerRsp(t.Struct):
+class StackStatusHandlerRsp(BaseCommand):
     network_state: t.uint8_t
 
 
-class StackStatusHandlerInd(t.Struct):
+class StackStatusHandlerInd(BaseCommand):
     network_state: t.uint8_t
 
 
-class ApsDataRequestReq(t.Struct):
+class ApsDataRequestReq(BaseCommand):
     dst_addr: t.EUI64
     dst_endpoint: t.uint8_t
     src_endpoint: t.uint8_t
@@ -376,19 +380,19 @@ class ApsDataRequestReq(t.Struct):
     asdu: Bytes
 
 
-class ApsDataRequestRsp(t.Struct):
+class ApsDataRequestRsp(BaseCommand):
     status: Status
 
 
-class ApsDataRequestInd(t.Struct):
+class ApsDataRequestInd(BaseCommand):
     pass
 
 
-class ApsDataIndicationReq(t.Struct):
+class ApsDataIndicationReq(BaseCommand):
     pass
 
 
-class ApsDataIndicationRsp(t.Struct):
+class ApsDataIndicationRsp(BaseCommand):
     network_state: NetworkState
     dst_addr_mode: ExtendedAddrMode
     dst_addr: t.EUI64
@@ -406,7 +410,7 @@ class ApsDataIndicationRsp(t.Struct):
     asdu: Bytes
 
 
-class ApsDataIndicationInd(t.Struct):
+class ApsDataIndicationInd(BaseCommand):
     network_state: NetworkState
     dst_addr_mode: ExtendedAddrMode
     dst_addr: t.EUI64
@@ -424,11 +428,11 @@ class ApsDataIndicationInd(t.Struct):
     asdu: Bytes
 
 
-class ApsDataConfirmReq(t.Struct):
+class ApsDataConfirmReq(BaseCommand):
     pass
 
 
-class ApsDataConfirmRsp(t.Struct):
+class ApsDataConfirmRsp(BaseCommand):
     network_state: NetworkState
     dst_addr_mode: ExtendedAddrMode
     dst_addr: t.EUI64
@@ -441,7 +445,7 @@ class ApsDataConfirmRsp(t.Struct):
     asdu: Bytes
 
 
-class ApsDataConfirmInd(t.Struct):
+class ApsDataConfirmInd(BaseCommand):
     network_state: NetworkState
     dst_addr_mode: ExtendedAddrMode
     dst_addr: t.EUI64
@@ -453,184 +457,184 @@ class ApsDataConfirmInd(t.Struct):
     asdu: Bytes
 
 
-class NetworkKeyGetReq(t.Struct):
+class NetworkKeyGetReq(BaseCommand):
     pass
 
 
-class NetworkKeyGetRsp(t.Struct):
+class NetworkKeyGetRsp(BaseCommand):
     nwk_key: t.KeyData
 
 
-class NetworkKeyGetInd(t.Struct):
+class NetworkKeyGetInd(BaseCommand):
     pass
 
 
-class NetworkKeySetReq(t.Struct):
+class NetworkKeySetReq(BaseCommand):
     nwk_key: t.KeyData
 
 
-class NetworkKeySetRsp(t.Struct):
+class NetworkKeySetRsp(BaseCommand):
     status: Status
 
 
-class NetworkKeySetInd(t.Struct):
+class NetworkKeySetInd(BaseCommand):
     pass
 
 
-class NwkFrameCounterGetReq(t.Struct):
+class NwkFrameCounterGetReq(BaseCommand):
     pass
 
 
-class NwkFrameCounterGetRsp(t.Struct):
+class NwkFrameCounterGetRsp(BaseCommand):
     nwk_frame_counter: t.uint32_t
 
 
-class NwkFrameCounterGetInd(t.Struct):
+class NwkFrameCounterGetInd(BaseCommand):
     pass
 
 
-class NwkFrameCounterSetReq(t.Struct):
+class NwkFrameCounterSetReq(BaseCommand):
     nwk_frame_counter: t.uint32_t
 
 
-class NwkFrameCounterSetRsp(t.Struct):
+class NwkFrameCounterSetRsp(BaseCommand):
     status: Status
 
 
-class NwkFrameCounterSetInd(t.Struct):
+class NwkFrameCounterSetInd(BaseCommand):
     pass
 
 
-class NetworkRoleGetReq(t.Struct):
+class NetworkRoleGetReq(BaseCommand):
     pass
 
 
-class NetworkRoleGetRsp(t.Struct):
+class NetworkRoleGetRsp(BaseCommand):
     role: DeviceType
 
 
-class NetworkRoleGetInd(t.Struct):
+class NetworkRoleGetInd(BaseCommand):
     pass
 
 
-class NetworkRoleSetReq(t.Struct):
+class NetworkRoleSetReq(BaseCommand):
     role: DeviceType
 
 
-class NetworkRoleSetRsp(t.Struct):
+class NetworkRoleSetRsp(BaseCommand):
     status: Status
 
 
-class NetworkRoleSetInd(t.Struct):
+class NetworkRoleSetInd(BaseCommand):
     pass
 
 
-class UsePredefinedNwkPanidSetReq(t.Struct):
+class UsePredefinedNwkPanidSetReq(BaseCommand):
     predefined: t.Bool
 
 
-class UsePredefinedNwkPanidSetRsp(t.Struct):
+class UsePredefinedNwkPanidSetRsp(BaseCommand):
     status: Status
 
 
-class UsePredefinedNwkPanidSetInd(t.Struct):
+class UsePredefinedNwkPanidSetInd(BaseCommand):
     pass
 
 
-class NwkUpdateIdGetReq(t.Struct):
+class NwkUpdateIdGetReq(BaseCommand):
     pass
 
 
-class NwkUpdateIdGetRsp(t.Struct):
+class NwkUpdateIdGetRsp(BaseCommand):
     nwk_update_id: t.uint8_t
 
 
-class NwkUpdateIdGetInd(t.Struct):
+class NwkUpdateIdGetInd(BaseCommand):
     pass
 
 
-class NwkUpdateIdSetReq(t.Struct):
+class NwkUpdateIdSetReq(BaseCommand):
     nwk_update_id: t.uint8_t
 
 
-class NwkUpdateIdSetRsp(t.Struct):
+class NwkUpdateIdSetRsp(BaseCommand):
     status: Status
 
 
-class NwkUpdateIdSetInd(t.Struct):
+class NwkUpdateIdSetInd(BaseCommand):
     pass
 
 
-class TrustCenterAddressGetReq(t.Struct):
+class TrustCenterAddressGetReq(BaseCommand):
     pass
 
 
-class TrustCenterAddressGetRsp(t.Struct):
+class TrustCenterAddressGetRsp(BaseCommand):
     trust_center_addr: t.EUI64
 
 
-class TrustCenterAddressGetInd(t.Struct):
+class TrustCenterAddressGetInd(BaseCommand):
     pass
 
 
-class TrustCenterAddressSetReq(t.Struct):
+class TrustCenterAddressSetReq(BaseCommand):
     trust_center_addr: t.EUI64
 
 
-class TrustCenterAddressSetRsp(t.Struct):
+class TrustCenterAddressSetRsp(BaseCommand):
     status: Status
 
 
-class TrustCenterAddressSetInd(t.Struct):
+class TrustCenterAddressSetInd(BaseCommand):
     pass
 
 
-class LinkKeyGetReq(t.Struct):
+class LinkKeyGetReq(BaseCommand):
     pass
 
 
-class LinkKeyGetRsp(t.Struct):
+class LinkKeyGetRsp(BaseCommand):
     ieee: t.EUI64
     key: t.KeyData
 
 
-class LinkKeyGetInd(t.Struct):
+class LinkKeyGetInd(BaseCommand):
     pass
 
 
-class LinkKeySetReq(t.Struct):
+class LinkKeySetReq(BaseCommand):
     key: t.KeyData
 
 
-class LinkKeySetRsp(t.Struct):
+class LinkKeySetRsp(BaseCommand):
     status: Status
 
 
-class LinkKeySetInd(t.Struct):
+class LinkKeySetInd(BaseCommand):
     pass
 
 
-class SecurityModeGetReq(t.Struct):
+class SecurityModeGetReq(BaseCommand):
     pass
 
 
-class SecurityModeGetRsp(t.Struct):
+class SecurityModeGetRsp(BaseCommand):
     security_mode: SecurityMode
 
 
-class SecurityModeGetInd(t.Struct):
+class SecurityModeGetInd(BaseCommand):
     pass
 
 
-class SecurityModeSetReq(t.Struct):
+class SecurityModeSetReq(BaseCommand):
     security_mode: SecurityMode
 
 
-class SecurityModeSetRsp(t.Struct):
+class SecurityModeSetRsp(BaseCommand):
     status: Status
 
 
-class SecurityModeSetInd(t.Struct):
+class SecurityModeSetInd(BaseCommand):
     pass
 
 
@@ -825,4 +829,8 @@ COMMAND_SCHEMAS = {
         SecurityModeSetRsp,
         SecurityModeSetInd,
     ),
+}
+
+COMMAND_SCHEMA_TO_COMMAND_ID = {
+    req: command_id for command_id, (req, _, _) in COMMAND_SCHEMAS.items()
 }

--- a/zigpy_espzb/commands.py
+++ b/zigpy_espzb/commands.py
@@ -95,24 +95,6 @@ class Command(t.Struct):
     payload: Bytes
 
 
-class FormNetwork(t.Struct):
-    role: DeviceType
-    install_code_policy: t.Bool
-
-    # For coordinators/routers
-    max_children: t.uint8_t = t.StructField(
-        requires=lambda f: f.role in (DeviceType.ROUTER, DeviceType.COORDINATOR)
-    )
-
-    # For end devices
-    ed_timeout: t.uint8_t = t.StructField(
-        requires=lambda f: f.role == DeviceType.END_DEVICE
-    )
-    keep_alive: t.uint32_t = t.StructField(
-        requires=lambda f: f.role == DeviceType.END_DEVICE
-    )
-
-
 class NetworkInitReq(t.Struct):
     pass
 
@@ -138,7 +120,21 @@ class StartInd(t.Struct):
 
 
 class FormNetworkReq(t.Struct):
-    form_nwk: FormNetwork
+    role: DeviceType
+    install_code_policy: t.Bool
+
+    # For coordinators/routers
+    max_children: t.uint8_t = t.StructField(
+        requires=lambda f: f.role in (DeviceType.ROUTER, DeviceType.COORDINATOR)
+    )
+
+    # For end devices
+    ed_timeout: t.uint8_t = t.StructField(
+        requires=lambda f: f.role == DeviceType.END_DEVICE
+    )
+    keep_alive: t.uint32_t = t.StructField(
+        requires=lambda f: f.role == DeviceType.END_DEVICE
+    )
 
 
 class FormNetworkRsp(t.Struct):

--- a/zigpy_espzb/commands.py
+++ b/zigpy_espzb/commands.py
@@ -107,20 +107,12 @@ class NetworkInitRsp(BaseCommand):
     status: Status
 
 
-class NetworkInitInd(BaseCommand):
-    pass
-
-
 class StartReq(BaseCommand):
     autostart: t.Bool
 
 
 class StartRsp(BaseCommand):
     status: Status
-
-
-class StartInd(BaseCommand):
-    pass
 
 
 class FormNetworkReq(BaseCommand):
@@ -185,20 +177,12 @@ class ExtpanidGetRsp(BaseCommand):
     ieee: t.EUI64
 
 
-class ExtpanidGetInd(BaseCommand):
-    pass
-
-
 class ExtpanidSetReq(BaseCommand):
     ieee: t.EUI64
 
 
 class ExtpanidSetRsp(BaseCommand):
     status: Status
-
-
-class ExtpanidSetInd(BaseCommand):
-    pass
 
 
 class PanidGetReq(BaseCommand):
@@ -209,20 +193,12 @@ class PanidGetRsp(BaseCommand):
     panid: t.PanId
 
 
-class PanidGetInd(BaseCommand):
-    pass
-
-
 class PanidSetReq(BaseCommand):
     panid: t.PanId
 
 
 class PanidSetRsp(BaseCommand):
     status: Status
-
-
-class PanidSetInd(BaseCommand):
-    pass
 
 
 class ShortAddrGetReq(BaseCommand):
@@ -233,20 +209,12 @@ class ShortAddrGetRsp(BaseCommand):
     short_addr: t.NWK
 
 
-class ShortAddrGetInd(BaseCommand):
-    pass
-
-
 class ShortAddrSetReq(BaseCommand):
     short_addr: t.NWK
 
 
 class ShortAddrSetRsp(BaseCommand):
     status: Status
-
-
-class ShortAddrSetInd(BaseCommand):
-    pass
 
 
 class LongAddrGetReq(BaseCommand):
@@ -257,20 +225,12 @@ class LongAddrGetRsp(BaseCommand):
     ieee: t.EUI64
 
 
-class LongAddrGetInd(BaseCommand):
-    pass
-
-
 class LongAddrSetReq(BaseCommand):
     ieee: t.EUI64
 
 
 class LongAddrSetRsp(BaseCommand):
     status: Status
-
-
-class LongAddrSetInd(BaseCommand):
-    pass
 
 
 class CurrentChannelGetReq(BaseCommand):
@@ -281,20 +241,12 @@ class CurrentChannelGetRsp(BaseCommand):
     channel: t.uint8_t
 
 
-class CurrentChannelGetInd(BaseCommand):
-    pass
-
-
 class CurrentChannelSetReq(BaseCommand):
     channel: t.uint8_t
 
 
 class CurrentChannelSetRsp(BaseCommand):
     status: Status
-
-
-class CurrentChannelSetInd(BaseCommand):
-    pass
 
 
 class PrimaryChannelMaskGetReq(BaseCommand):
@@ -305,20 +257,12 @@ class PrimaryChannelMaskGetRsp(BaseCommand):
     channel_mask: ShiftedChannels
 
 
-class PrimaryChannelMaskGetInd(BaseCommand):
-    pass
-
-
 class PrimaryChannelMaskSetReq(BaseCommand):
     channel_mask: ShiftedChannels
 
 
 class PrimaryChannelMaskSetRsp(BaseCommand):
     status: Status
-
-
-class PrimaryChannelMaskSetInd(BaseCommand):
-    pass
 
 
 class AddEndpointReq(BaseCommand):
@@ -336,20 +280,12 @@ class AddEndpointRsp(BaseCommand):
     status: Status
 
 
-class AddEndpointInd(BaseCommand):
-    pass
-
-
 class NetworkStateReq(BaseCommand):
     pass
 
 
 class NetworkStateRsp(BaseCommand):
     network_state: NetworkState
-
-
-class NetworkStateInd(BaseCommand):
-    pass
 
 
 class StackStatusHandlerReq(BaseCommand):
@@ -382,14 +318,6 @@ class ApsDataRequestReq(BaseCommand):
 
 class ApsDataRequestRsp(BaseCommand):
     status: Status
-
-
-class ApsDataRequestInd(BaseCommand):
-    pass
-
-
-class ApsDataIndicationReq(BaseCommand):
-    pass
 
 
 class ApsDataIndicationRsp(BaseCommand):
@@ -465,20 +393,12 @@ class NetworkKeyGetRsp(BaseCommand):
     nwk_key: t.KeyData
 
 
-class NetworkKeyGetInd(BaseCommand):
-    pass
-
-
 class NetworkKeySetReq(BaseCommand):
     nwk_key: t.KeyData
 
 
 class NetworkKeySetRsp(BaseCommand):
     status: Status
-
-
-class NetworkKeySetInd(BaseCommand):
-    pass
 
 
 class NwkFrameCounterGetReq(BaseCommand):
@@ -489,20 +409,12 @@ class NwkFrameCounterGetRsp(BaseCommand):
     nwk_frame_counter: t.uint32_t
 
 
-class NwkFrameCounterGetInd(BaseCommand):
-    pass
-
-
 class NwkFrameCounterSetReq(BaseCommand):
     nwk_frame_counter: t.uint32_t
 
 
 class NwkFrameCounterSetRsp(BaseCommand):
     status: Status
-
-
-class NwkFrameCounterSetInd(BaseCommand):
-    pass
 
 
 class NetworkRoleGetReq(BaseCommand):
@@ -513,20 +425,12 @@ class NetworkRoleGetRsp(BaseCommand):
     role: DeviceType
 
 
-class NetworkRoleGetInd(BaseCommand):
-    pass
-
-
 class NetworkRoleSetReq(BaseCommand):
     role: DeviceType
 
 
 class NetworkRoleSetRsp(BaseCommand):
     status: Status
-
-
-class NetworkRoleSetInd(BaseCommand):
-    pass
 
 
 class UsePredefinedNwkPanidSetReq(BaseCommand):
@@ -537,20 +441,12 @@ class UsePredefinedNwkPanidSetRsp(BaseCommand):
     status: Status
 
 
-class UsePredefinedNwkPanidSetInd(BaseCommand):
-    pass
-
-
 class NwkUpdateIdGetReq(BaseCommand):
     pass
 
 
 class NwkUpdateIdGetRsp(BaseCommand):
     nwk_update_id: t.uint8_t
-
-
-class NwkUpdateIdGetInd(BaseCommand):
-    pass
 
 
 class NwkUpdateIdSetReq(BaseCommand):
@@ -561,10 +457,6 @@ class NwkUpdateIdSetRsp(BaseCommand):
     status: Status
 
 
-class NwkUpdateIdSetInd(BaseCommand):
-    pass
-
-
 class TrustCenterAddressGetReq(BaseCommand):
     pass
 
@@ -573,20 +465,12 @@ class TrustCenterAddressGetRsp(BaseCommand):
     trust_center_addr: t.EUI64
 
 
-class TrustCenterAddressGetInd(BaseCommand):
-    pass
-
-
 class TrustCenterAddressSetReq(BaseCommand):
     trust_center_addr: t.EUI64
 
 
 class TrustCenterAddressSetRsp(BaseCommand):
     status: Status
-
-
-class TrustCenterAddressSetInd(BaseCommand):
-    pass
 
 
 class LinkKeyGetReq(BaseCommand):
@@ -598,20 +482,12 @@ class LinkKeyGetRsp(BaseCommand):
     key: t.KeyData
 
 
-class LinkKeyGetInd(BaseCommand):
-    pass
-
-
 class LinkKeySetReq(BaseCommand):
     key: t.KeyData
 
 
 class LinkKeySetRsp(BaseCommand):
     status: Status
-
-
-class LinkKeySetInd(BaseCommand):
-    pass
 
 
 class SecurityModeGetReq(BaseCommand):
@@ -622,10 +498,6 @@ class SecurityModeGetRsp(BaseCommand):
     security_mode: SecurityMode
 
 
-class SecurityModeGetInd(BaseCommand):
-    pass
-
-
 class SecurityModeSetReq(BaseCommand):
     security_mode: SecurityMode
 
@@ -634,20 +506,16 @@ class SecurityModeSetRsp(BaseCommand):
     status: Status
 
 
-class SecurityModeSetInd(BaseCommand):
-    pass
-
-
 COMMAND_SCHEMAS = {
     CommandId.network_init: (
         NetworkInitReq,
         NetworkInitRsp,
-        NetworkInitInd,
+        None,
     ),
     CommandId.start: (
         StartReq,
         StartRsp,
-        StartInd,
+        None,
     ),
     CommandId.form_network: (
         FormNetworkReq,
@@ -667,72 +535,72 @@ COMMAND_SCHEMAS = {
     CommandId.extpanid_get: (
         ExtpanidGetReq,
         ExtpanidGetRsp,
-        ExtpanidGetInd,
+        None,
     ),
     CommandId.extpanid_set: (
         ExtpanidSetReq,
         ExtpanidSetRsp,
-        ExtpanidSetInd,
+        None,
     ),
     CommandId.panid_get: (
         PanidGetReq,
         PanidGetRsp,
-        PanidGetInd,
+        None,
     ),
     CommandId.panid_set: (
         PanidSetReq,
         PanidSetRsp,
-        PanidSetInd,
+        None,
     ),
     CommandId.short_addr_get: (
         ShortAddrGetReq,
         ShortAddrGetRsp,
-        ShortAddrGetInd,
+        None,
     ),
     CommandId.short_addr_set: (
         ShortAddrSetReq,
         ShortAddrSetRsp,
-        ShortAddrSetInd,
+        None,
     ),
     CommandId.long_addr_get: (
         LongAddrGetReq,
         LongAddrGetRsp,
-        LongAddrGetInd,
+        None,
     ),
     CommandId.long_addr_set: (
         LongAddrSetReq,
         LongAddrSetRsp,
-        LongAddrSetInd,
+        None,
     ),
     CommandId.current_channel_get: (
         CurrentChannelGetReq,
         CurrentChannelGetRsp,
-        CurrentChannelGetInd,
+        None,
     ),
     CommandId.current_channel_set: (
         CurrentChannelSetReq,
         CurrentChannelSetRsp,
-        CurrentChannelSetInd,
+        None,
     ),
     CommandId.primary_channel_mask_get: (
         PrimaryChannelMaskGetReq,
         PrimaryChannelMaskGetRsp,
-        PrimaryChannelMaskGetInd,
+        None,
     ),
     CommandId.primary_channel_mask_set: (
         PrimaryChannelMaskSetReq,
         PrimaryChannelMaskSetRsp,
-        PrimaryChannelMaskSetInd,
+        None,
     ),
     CommandId.add_endpoint: (
         AddEndpointReq,
         AddEndpointRsp,
-        AddEndpointInd,
+        None,
     ),
     CommandId.network_state: (
         NetworkStateReq,
         NetworkStateRsp,
-        NetworkStateInd,
+        None,
     ),
     CommandId.stack_status_handler: (
         StackStatusHandlerReq,
@@ -742,10 +610,10 @@ COMMAND_SCHEMAS = {
     CommandId.aps_data_request: (
         ApsDataRequestReq,
         ApsDataRequestRsp,
-        ApsDataRequestInd,
+        None,
     ),
     CommandId.aps_data_indication: (
-        ApsDataIndicationReq,
+        None,
         ApsDataIndicationRsp,
         ApsDataIndicationInd,
     ),
@@ -757,77 +625,77 @@ COMMAND_SCHEMAS = {
     CommandId.network_key_get: (
         NetworkKeyGetReq,
         NetworkKeyGetRsp,
-        NetworkKeyGetInd,
+        None,
     ),
     CommandId.network_key_set: (
         NetworkKeySetReq,
         NetworkKeySetRsp,
-        NetworkKeySetInd,
+        None,
     ),
     CommandId.nwk_frame_counter_get: (
         NwkFrameCounterGetReq,
         NwkFrameCounterGetRsp,
-        NwkFrameCounterGetInd,
+        None,
     ),
     CommandId.nwk_frame_counter_set: (
         NwkFrameCounterSetReq,
         NwkFrameCounterSetRsp,
-        NwkFrameCounterSetInd,
+        None,
     ),
     CommandId.network_role_get: (
         NetworkRoleGetReq,
         NetworkRoleGetRsp,
-        NetworkRoleGetInd,
+        None,
     ),
     CommandId.network_role_set: (
         NetworkRoleSetReq,
         NetworkRoleSetRsp,
-        NetworkRoleSetInd,
+        None,
     ),
     CommandId.use_predefined_nwk_panid_set: (
         UsePredefinedNwkPanidSetReq,
         UsePredefinedNwkPanidSetRsp,
-        UsePredefinedNwkPanidSetInd,
+        None,
     ),
     CommandId.nwk_update_id_get: (
         NwkUpdateIdGetReq,
         NwkUpdateIdGetRsp,
-        NwkUpdateIdGetInd,
+        None,
     ),
     CommandId.nwk_update_id_set: (
         NwkUpdateIdSetReq,
         NwkUpdateIdSetRsp,
-        NwkUpdateIdSetInd,
+        None,
     ),
     CommandId.trust_center_address_get: (
         TrustCenterAddressGetReq,
         TrustCenterAddressGetRsp,
-        TrustCenterAddressGetInd,
+        None,
     ),
     CommandId.trust_center_address_set: (
         TrustCenterAddressSetReq,
         TrustCenterAddressSetRsp,
-        TrustCenterAddressSetInd,
+        None,
     ),
     CommandId.link_key_get: (
         LinkKeyGetReq,
         LinkKeyGetRsp,
-        LinkKeyGetInd,
+        None,
     ),
     CommandId.link_key_set: (
         LinkKeySetReq,
         LinkKeySetRsp,
-        LinkKeySetInd,
+        None,
     ),
     CommandId.security_mode_get: (
         SecurityModeGetReq,
         SecurityModeGetRsp,
-        SecurityModeGetInd,
+        None,
     ),
     CommandId.security_mode_set: (
         SecurityModeSetReq,
         SecurityModeSetRsp,
-        SecurityModeSetInd,
+        None,
     ),
 }
 

--- a/zigpy_espzb/commands.py
+++ b/zigpy_espzb/commands.py
@@ -520,6 +520,8 @@ class SystemResetReq(BaseCommand):
 class SystemResetRsp(BaseCommand):
     status: Status
 
+class SystemResetInd(BaseCommand):
+    error: t.uint32_t
 
 class SystemFactoryReq(BaseCommand):
     pass
@@ -528,6 +530,8 @@ class SystemFactoryReq(BaseCommand):
 class SystemFactoryRsp(BaseCommand):
     status: Status
 
+class SystemFactoryInd(BaseCommand):
+    error: t.uint32_t
 
 class SystemFirmwareReq(BaseCommand):
     pass
@@ -747,12 +751,12 @@ COMMAND_SCHEMAS = {
     CommandId.system_reset: (
         SystemResetReq,
         SystemResetRsp,
-        None,
+        SystemResetInd,
     ),
     CommandId.system_factory: (
         SystemFactoryReq,
         SystemFactoryRsp,
-        None,
+        SystemFactoryInd,
     ),
     CommandId.system_firmware: (
         SystemFirmwareReq,

--- a/zigpy_espzb/types.py
+++ b/zigpy_espzb/types.py
@@ -115,3 +115,59 @@ class ShiftedChannels(t.bitmap32):
     def from_zigpy_channels(cls, channels: t.Channels) -> ShiftedChannels:
         """Convert a Zigpy Channels to a ShiftedChannels."""
         return cls.from_channel_list(tuple(channels))
+
+
+class DeviceType(t.enum8):
+    COORDINATOR = 0x00
+    ROUTER = 0x01
+    END_DEVICE = 0x02
+    NONE = 0x03
+
+
+class Status(t.enum8):
+    SUCCESS = 0
+    FAILURE = 1
+    INVALID_VALUE = 2
+    TIMEOUT = 3
+    UNSUPPORTED = 4
+    ERROR = 5
+    NO_NETWORK = 6
+    BUSY = 7
+
+
+class FirmwareVersion(t.Struct, t.uint32_t):
+    reserved: t.uint8_t
+    patch: t.uint8_t
+    minor: t.uint8_t
+    major: t.uint8_t
+
+
+class NetworkState(t.enum8):
+    OFFLINE = 0
+    JOINING = 1
+    CONNECTED = 2
+    LEAVING = 3
+    CONFIRM = 4
+    INDICATION = 5
+
+
+class SecurityMode(t.enum8):
+    NO_SECURITY = 0x00
+    PRECONFIGURED_NETWORK_KEY = 0x01
+
+
+class ZDPResponseHandling(t.bitmap16):
+    NONE = 0x0000
+    NodeDescRsp = 0x0001
+
+
+class TXStatus(t.enum8):
+    SUCCESS = 0x00
+
+    @classmethod
+    def _missing_(cls, value):
+        chained = t.APSStatus(value)
+        status = t.uint8_t.__new__(cls, chained.value)
+        status._name_ = chained.name
+        status._value_ = value
+        return status

--- a/zigpy_espzb/types.py
+++ b/zigpy_espzb/types.py
@@ -5,40 +5,6 @@ from __future__ import annotations
 import zigpy.types as t
 
 
-def serialize_dict(data, schema):
-    chunks = []
-
-    for key in schema:
-        value = data[key]
-        if value is None:
-            break
-
-        if not isinstance(value, schema[key]):
-            value = schema[key](value)
-
-        chunks.append(value.serialize())
-
-    return b"".join(chunks)
-
-
-def deserialize_dict(data, schema):
-    result = {}
-    for name, type_ in schema.items():
-        try:
-            result[name], data = type_.deserialize(data)
-        except ValueError:
-            if data:
-                raise
-
-            result[name] = None
-    return result, data
-
-
-def list_replace(lst: list, old: object, new: object) -> list:
-    """Replace all occurrences of `old` with `new` in `lst`."""
-    return [new if x == old else x for x in lst]
-
-
 class Bytes(bytes):
     def serialize(self):
         return self
@@ -48,18 +14,52 @@ class Bytes(bytes):
         return cls(data), b""
 
 
-class ZnspTransmitOptions(t.bitmap8):
+class TransmitOptions(t.bitmap8):
     NONE = 0x00
-    ACK_ENABLED = 0x01
-    SECURITY_ENABLED = 0x02
+
+    # Security enabled transmission
+    SECURITY_ENABLED = 0x01
+    # Use NWK key (obsolete)
+    USE_NWK_KEY_R21OBSOLETE = 0x02
+    # Extension: do not include long src/dst addresses into NWK hdr
+    NO_LONG_ADDR = 0x02
+    # Acknowledged transmission
+    ACK_TX = 0x04
+    # Fragmentation permitted
+    FRAG_PERMITTED = 0x08
+    # Include extended nonce in APS security frame
+    INC_EXT_NONCE = 0x10
 
 
 class ExtendedAddrMode(t.enum8):
-    Unknown = 0x00
-    IEEE = 0x01
-    NWK = 0x02
-    Group = 0x03
-    Broadcast = 0x0F
+    # DstAddress and DstEndpoint not present
+    MODE_DST_ADDR_ENDP_NOT_PRESENT = 0x00
+    # 16-bit group address for DstAddress; DstEndpoint not present
+    MODE_16_GROUP_ENDP_NOT_PRESENT = 0x01
+    # 16-bit address for DstAddress and DstEndpoint present
+    MODE_16_ENDP_PRESENT = 0x02
+    # 64-bit extended address for DstAddress and DstEndpoint present
+    MODE_64_ENDP_PRESENT = 0x03
+
+    @classmethod
+    def from_zigpy_addr_mode(cls, addr_mode: t.AddrMode) -> ExtendedAddrMode:
+        """Convert a Zigpy AddrMode to an ExtendedAddrMode."""
+        return {
+            t.AddrMode.IEEE: cls.MODE_64_ENDP_PRESENT,
+            t.AddrMode.NWK: cls.MODE_16_ENDP_PRESENT,
+            t.AddrMode.Group: cls.MODE_16_GROUP_ENDP_NOT_PRESENT,
+            t.AddrMode.Broadcast: cls.MODE_16_GROUP_ENDP_NOT_PRESENT,
+        }[addr_mode]
+
+    def to_zigpy_addr_mode(self) -> t.AddrMode:
+        """Convert a Zigpy AddrMode to an ExtendedAddrMode."""
+        return {
+            self.MODE_64_ENDP_PRESENT: t.AddrMode.IEEE,
+            self.MODE_16_ENDP_PRESENT: t.AddrMode.NWK,
+            self.MODE_DST_ADDR_ENDP_NOT_PRESENT: t.AddrMode.NWK,
+            self.MODE_16_GROUP_ENDP_NOT_PRESENT: t.AddrMode.Group,
+            self.MODE_16_GROUP_ENDP_NOT_PRESENT: t.AddrMode.Broadcast,
+        }[self]
 
 
 def addr_mode_with_eui64_to_addr_mode_address(
@@ -67,46 +67,45 @@ def addr_mode_with_eui64_to_addr_mode_address(
 ) -> t.AddrModeAddress:
     """Convert an address mode and an EUI64 address to an AddrModeAddress."""
     address_short, _ = t.uint16_t.deserialize(address.serialize()[:2])
+    zigpy_addr_mode = addr_mode.to_zigpy_addr_mode()
 
-    if addr_mode == ExtendedAddrMode.IEEE:
+    if zigpy_addr_mode == t.AddrMode.IEEE:
         address = address
-    elif addr_mode == ExtendedAddrMode.NWK:
+    elif zigpy_addr_mode == t.AddrMode.NWK:
         address = t.NWK(address_short)
-    elif addr_mode == ExtendedAddrMode.Group:
+    elif zigpy_addr_mode == t.AddrMode.Group:
         address = t.Group(address_short)
-    elif addr_mode == ExtendedAddrMode.Broadcast:
+    elif zigpy_addr_mode == t.AddrMode.Broadcast:
         address = t.BroadcastAddress(address_short)
-    elif addr_mode == ExtendedAddrMode.Unknown:
-        # TODO: Is this correct? It seems to be used only for loopback
-        address = address_short
-        addr_mode = t.AddrMode.NWK
     else:
-        raise ValueError(f"Unknown address mode: {addr_mode}")
+        raise ValueError(f"Unknown address mode: {zigpy_addr_mode}")
 
-    return t.AddrModeAddress(addr_mode=t.AddrMode(addr_mode), address=address)
+    return t.AddrModeAddress(addr_mode=zigpy_addr_mode, address=address)
 
 
 class ShiftedChannels(t.bitmap32):
     """Zigbee Channels."""
 
-    CHANNEL_11 = 0b00000000000000000000010000000000
-    CHANNEL_12 = 0b00000000000000000000100000000000
-    CHANNEL_13 = 0b00000000000000000001000000000000
-    CHANNEL_14 = 0b00000000000000000010000000000000
-    CHANNEL_15 = 0b00000000000000000100000000000000
-    CHANNEL_16 = 0b00000000000000001000000000000000
-    CHANNEL_17 = 0b00000000000000010000000000000000
-    CHANNEL_18 = 0b00000000000000100000000000000000
-    CHANNEL_19 = 0b00000000000001000000000000000000
-    CHANNEL_20 = 0b00000000000010000000000000000000
-    CHANNEL_21 = 0b00000000000100000000000000000000
-    CHANNEL_22 = 0b00000000001000000000000000000000
-    CHANNEL_23 = 0b00000000010000000000000000000000
-    CHANNEL_24 = 0b00000000100000000000000000000000
-    CHANNEL_25 = 0b00000001000000000000000000000000
-    CHANNEL_26 = 0b00000010000000000000000000000000
-    ALL_CHANNELS = 0b00000011111111111111110000000000
-    NO_CHANNELS = 0b00000000000000000000000000000000
+    # fmt: off
+    CHANNEL_11 =   0b00000000000000000000100000000000
+    CHANNEL_12 =   0b00000000000000000001000000000000
+    CHANNEL_13 =   0b00000000000000000010000000000000
+    CHANNEL_14 =   0b00000000000000000100000000000000
+    CHANNEL_15 =   0b00000000000000001000000000000000
+    CHANNEL_16 =   0b00000000000000010000000000000000
+    CHANNEL_17 =   0b00000000000000100000000000000000
+    CHANNEL_18 =   0b00000000000001000000000000000000
+    CHANNEL_19 =   0b00000000000010000000000000000000
+    CHANNEL_20 =   0b00000000000100000000000000000000
+    CHANNEL_21 =   0b00000000001000000000000000000000
+    CHANNEL_22 =   0b00000000010000000000000000000000
+    CHANNEL_23 =   0b00000000100000000000000000000000
+    CHANNEL_24 =   0b00000001000000000000000000000000
+    CHANNEL_25 =   0b00000010000000000000000000000000
+    CHANNEL_26 =   0b00000100000000000000000000000000
+    ALL_CHANNELS = 0b00000111111111111111100000000000
+    NO_CHANNELS =  0b00000000000000000000000000000000
+    # fmt: on
 
     __iter__ = t.Channels.__iter__
     from_channel_list = classmethod(t.Channels.from_channel_list.__func__)

--- a/zigpy_espzb/types.py
+++ b/zigpy_espzb/types.py
@@ -1,6 +1,8 @@
 """Data types module."""
 
-from zigpy.types import bitmap8
+from __future__ import annotations
+
+import zigpy.types as t
 
 
 def serialize_dict(data, schema):
@@ -46,12 +48,70 @@ class Bytes(bytes):
         return cls(data), b""
 
 
-class ZnspTransmitOptions(bitmap8):
+class ZnspTransmitOptions(t.bitmap8):
     NONE = 0x00
     ACK_ENABLED = 0x01
     SECURITY_ENABLED = 0x02
 
 
-class DeviceAddrMode:
-    # TODO: implement this class
-    pass
+class ExtendedAddrMode(t.enum8):
+    Unknown = 0x00
+    IEEE = 0x01
+    NWK = 0x02
+    Group = 0x03
+    Broadcast = 0x0F
+
+
+def addr_mode_with_eui64_to_addr_mode_address(
+    addr_mode: ExtendedAddrMode, address: t.EUI64
+) -> t.AddrModeAddress:
+    """Convert an address mode and an EUI64 address to an AddrModeAddress."""
+    address_short, _ = t.uint16_t.deserialize(address.serialize()[:2])
+
+    if addr_mode == ExtendedAddrMode.IEEE:
+        address = address
+    elif addr_mode == ExtendedAddrMode.NWK:
+        address = t.NWK(address_short)
+    elif addr_mode == ExtendedAddrMode.Group:
+        address = t.Group(address_short)
+    elif addr_mode == ExtendedAddrMode.Broadcast:
+        address = t.BroadcastAddress(address_short)
+    elif addr_mode == ExtendedAddrMode.Unknown:
+        # TODO: Is this correct? It seems to be used only for loopback
+        address = address_short
+        addr_mode = t.AddrMode.NWK
+    else:
+        raise ValueError(f"Unknown address mode: {addr_mode}")
+
+    return t.AddrModeAddress(addr_mode=t.AddrMode(addr_mode), address=address)
+
+
+class ShiftedChannels(t.bitmap32):
+    """Zigbee Channels."""
+
+    CHANNEL_11 = 0b00000000000000000000010000000000
+    CHANNEL_12 = 0b00000000000000000000100000000000
+    CHANNEL_13 = 0b00000000000000000001000000000000
+    CHANNEL_14 = 0b00000000000000000010000000000000
+    CHANNEL_15 = 0b00000000000000000100000000000000
+    CHANNEL_16 = 0b00000000000000001000000000000000
+    CHANNEL_17 = 0b00000000000000010000000000000000
+    CHANNEL_18 = 0b00000000000000100000000000000000
+    CHANNEL_19 = 0b00000000000001000000000000000000
+    CHANNEL_20 = 0b00000000000010000000000000000000
+    CHANNEL_21 = 0b00000000000100000000000000000000
+    CHANNEL_22 = 0b00000000001000000000000000000000
+    CHANNEL_23 = 0b00000000010000000000000000000000
+    CHANNEL_24 = 0b00000000100000000000000000000000
+    CHANNEL_25 = 0b00000001000000000000000000000000
+    CHANNEL_26 = 0b00000010000000000000000000000000
+    ALL_CHANNELS = 0b00000011111111111111110000000000
+    NO_CHANNELS = 0b00000000000000000000000000000000
+
+    __iter__ = t.Channels.__iter__
+    from_channel_list = classmethod(t.Channels.from_channel_list.__func__)
+
+    @classmethod
+    def from_zigpy_channels(cls, channels: t.Channels) -> ShiftedChannels:
+        """Convert a Zigpy Channels to a ShiftedChannels."""
+        return cls.from_channel_list(tuple(channels))

--- a/zigpy_espzb/types.py
+++ b/zigpy_espzb/types.py
@@ -59,6 +59,8 @@ class ExtendedAddrMode(t.enum8):
             self.MODE_DST_ADDR_ENDP_NOT_PRESENT: t.AddrMode.NWK,
             self.MODE_16_GROUP_ENDP_NOT_PRESENT: t.AddrMode.Group,
             self.MODE_16_GROUP_ENDP_NOT_PRESENT: t.AddrMode.Broadcast,
+            # TODO: why is this necessary?
+            0xFF: t.AddrMode.NWK,
         }[self]
 
 

--- a/zigpy_espzb/zigbee/application.py
+++ b/zigpy_espzb/zigbee/application.py
@@ -21,20 +21,12 @@ import zigpy.exceptions
 from zigpy.exceptions import FormationFailure, NetworkNotFormed
 import zigpy.state
 import zigpy.types
+import zigpy.types as t
 import zigpy.util
 import zigpy.zdo.types as zdo_t
 
-import zigpy_espzb
-from zigpy_espzb import types as t
-from zigpy_espzb.api import (
-    IndexedKey,
-    LinkKey,
-    NetworkState,
-    SecurityMode,
-    Status,
-    Znsp,
-)
-import zigpy_espzb.exception
+from zigpy_espzb.api import DeviceType, NetworkState, SecurityMode, Znsp
+import zigpy_espzb.types as espzb_t
 
 LOGGER = logging.getLogger(__name__)
 
@@ -64,11 +56,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         self._api = None
 
         self._pending = zigpy.util.Requests()
-
-        self._delayed_neighbor_scan_task = None
         self._reconnect_task = None
-
-        self._written_endpoints = set()
 
     async def _watchdog_feed(self):
         await self._api.set_watchdog_ttl(int(self._watchdog_period / 0.75))
@@ -82,41 +70,36 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             api.close()
             raise
 
+        await api.reset()
+
+        # TODO: Most commands fail if the network is not formed. Why?
+        await api.form_network(role=DeviceType.COORDINATOR)
+
         self._api = api
-        self._written_endpoints.clear()
 
     async def disconnect(self):
-        if self._delayed_neighbor_scan_task is not None:
-            self._delayed_neighbor_scan_task.cancel()
-            self._delayed_neighbor_scan_task = None
-
         if self._api is not None:
             self._api.close()
             self._api = None
 
     async def permit_with_link_key(self, node: t.EUI64, link_key: t.KeyData, time_s=60):
-        await self._api.set_link_key(
-            LinkKey(ieee=node, key=link_key),
-        )
-        await self.permit(time_s)
+        raise NotImplementedError()
 
     async def start_network(self):
+        await self._api.start(autostart=True)
+
         await self.register_endpoints()
         await self.load_network_info(load_devices=False)
-        await self._change_network_state(NetworkState.CONNECTED)
 
-        coordinator = await ZnspDevice.new(
-            self,
-            self.state.node_info.ieee,
-            self.state.node_info.nwk,
-            self.state.node_info.model,
+        # Create the coordinator device
+        coordinator = zigpy.device.Device(
+            application=self,
+            ieee=self.state.node_info.ieee,
+            nwk=self.state.node_info.nwk,
         )
-
         self.devices[self.state.node_info.ieee] = coordinator
 
-        self._delayed_neighbor_scan_task = asyncio.create_task(
-            self._delayed_neighbour_scan()
-        )
+        await coordinator.schedule_initialize()
 
     async def _change_network_state(
         self,
@@ -127,11 +110,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         async def change_loop():
             while True:
                 try:
-                    device_state = await self._api.get_device_state()
+                    network_state = await self._api.get_network_state()
                 except asyncio.TimeoutError:
                     LOGGER.debug("Failed to poll device state")
                 else:
-                    if NetworkState(device_state.network_state) == target_state:
+                    if network_state == target_state:
                         break
 
                 await asyncio.sleep(CHANGE_NETWORK_POLL_TIME)
@@ -148,22 +131,17 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             raise FormationFailure("Network formation refused.")
 
     async def reset_network_info(self):
-        await self.form_network()
+        await self._api.leave_network()
 
     async def write_network_info(self, *, network_info, node_info):
-        try:
-            await self._api.set_nwk_frame_counter(network_info.network_key.tx_counter)
-        except zigpy_espzb.exception.CommandError as ex:
-            assert ex.status == Status.UNSUPPORTED
-            LOGGER.warning(
-                "Doesn't support writing the network frame counter with this firmware"
-            )
+        await self._api.reset()
 
-        if node_info.logical_type == zdo_t.LogicalType.Coordinator:
-            await self._api.set_aps_designed_coordinator(1)
-        else:
-            await self._api.set_aps_designed_coordinator(0)
+        role = {
+            zdo_t.LogicalType.Coordinator: DeviceType.COORDINATOR,
+            zdo_t.LogicalType.Router: DeviceType.ROUTER,
+        }[node_info.logical_type]
 
+        await self._api.set_network_role(role)
         await self._api.set_nwk_address(node_info.nwk)
 
         if node_info.ieee != zigpy.types.EUI64.UNKNOWN:
@@ -173,29 +151,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             ieee = await self._api.mac_address()
             node_ieee = zigpy.types.EUI64(ieee)
 
-        if network_info.channel is not None:
-            channel_mask = zigpy.types.Channels.from_channel_list(
-                [network_info.channel]
-            )
-
-            if network_info.channel_mask and channel_mask != network_info.channel_mask:
-                LOGGER.warning(
-                    "Channel mask %s will be replaced with current logical channel %s",
-                    network_info.channel_mask,
-                    channel_mask,
-                )
-        else:
-            channel_mask = network_info.channel_mask
-
-        await self._api.set_channel_mask(channel_mask)
+        # TODO: Why does setting the PAN ID or extended PAN ID trigger a crash?
         await self._api.set_use_predefined_nwk_panid(True)
         await self._api.set_nwk_panid(network_info.pan_id)
-        await self._api.set_aps_extended_panid(network_info.extended_pan_id)
+        await self._api.set_nwk_extended_panid(network_info.extended_pan_id)
         await self._api.set_nwk_update_id(network_info.nwk_update_id)
-
-        await self._api.set_network_key(
-            IndexedKey(index=0, key=network_info.network_key.key),
-        )
+        await self._api.set_network_key(network_info.network_key.key)
+        await self._api.set_nwk_frame_counter(network_info.network_key.tx_counter)
 
         if network_info.network_key.seq != 0:
             LOGGER.warning(
@@ -208,91 +170,66 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if tc_link_key_partner_ieee == zigpy.types.EUI64.UNKNOWN:
             tc_link_key_partner_ieee = node_ieee
 
-        await self._api.set_trust_center_address(
-            tc_link_key_partner_ieee,
-        )
-        await self._api.set_link_key(
-            LinkKey(
-                ieee=tc_link_key_partner_ieee,
-                key=network_info.tc_link_key.key,
-            ),
-        )
+        await self._api.set_trust_center_address(tc_link_key_partner_ieee)
+        await self._api.set_link_key(network_info.tc_link_key.key)
 
         if network_info.security_level == 0x00:
             await self._api.set_security_mode(SecurityMode.NO_SECURITY)
         else:
-            await self._api.set_security_mode(SecurityMode.ONLY_TCLK)
+            await self._api.set_security_mode(SecurityMode.PRECONFIGURED_NETWORK_KEY)
 
-        await self._change_network_state(NetworkState.OFFLINE)
-        await asyncio.sleep(CHANGE_NETWORK_STATE_DELAY)
-        await self._change_network_state(NetworkState.CONNECTED)
+        await self._api.set_channel(network_info.channel)
+        await self._api.form_network(role=role)
+
+        await asyncio.sleep(1)
 
     async def load_network_info(self, *, load_devices=False):
         network_info = self.state.network_info
         node_info = self.state.node_info
 
-        ieee = await self._api.mac_address()
-        node_info.ieee = zigpy.types.EUI64(ieee)
-        designed_coord = await self._api.aps_designed_coordinator()
+        role = await self._api.get_network_role()
 
-        if designed_coord == 0x01:
+        if role == DeviceType.COORDINATOR:
             node_info.logical_type = zdo_t.LogicalType.Coordinator
         else:
             node_info.logical_type = zdo_t.LogicalType.Router
 
-        node_info.nwk = await self._api.nwk_address()
+        node_info.nwk = await self._api.get_nwk_address()
+        node_info.ieee = await self._api.get_mac_address()
 
+        # TODO: implement firmware commands to read the board name, manufacturer
         node_info.manufacturer = "Espressif Systems"
-
         node_info.model = "ESP32H2"
 
+        # TODO: implement firmware command to read out the firmware version and build ID
         node_info.version = f"{int(self._api.firmware_version):#010x}"
 
         network_info.source = f"zigpy-espzb@{importlib.metadata.version('zigpy-espzb')}"
-        network_info.metadata = {
-            "espzb": {
-                "version": node_info.version,
-            }
-        }
+        network_info.metadata = {}
 
-        network_info.pan_id = await self._api.nwk_panid()
-        network_info.extended_pan_id = await self._api.aps_extended_panid()
+        network_info.pan_id = await self._api.get_nwk_panid()
+        network_info.extended_pan_id = await self._api.get_nwk_extended_panid()
+        network_info.channel = await self._api.get_current_channel()
+        network_info.channel_mask = await self._api.get_channel_mask()
+        network_info.nwk_update_id = await self._api.get_nwk_update_id()
 
-        if network_info.extended_pan_id == zigpy.types.EUI64.convert(
-            "00:00:00:00:00:00:00:00"
-        ):
-            network_info.extended_pan_id = await self._api.nwk_extended_panid()
+        if network_info.channel in (0, 255):
+            raise NetworkNotFormed(f"Channel is invalid: {network_info.channel}")
 
-        network_info.channel = await self._api.current_channel()
-        network_info.channel_mask = await self._api.channel_mask()
-        network_info.nwk_update_id = await self._api.nwk_update_id()
-
-        if network_info.channel == 0:
-            raise NetworkNotFormed("Network channel is zero")
-
-        indexed_key = await self._api.network_key()
-
-        network_info.network_key = zigpy.state.Key()
-        network_info.network_key.key = indexed_key.key
-
-        try:
-            network_info.network_key.tx_counter = await self._api.nwk_frame_counter()
-        except zigpy_espzb.exception.CommandError as ex:
-            assert ex.status == Status.UNSUPPORTED
+        network_info.network_key.key = await self._api.get_network_key()
+        network_info.network_key.tx_counter = await self._api.get_nwk_frame_counter()
 
         network_info.tc_link_key = zigpy.state.Key()
-        network_info.tc_link_key.partner_ieee = await self._api.trust_center_address()
-
-        link_key = await self._api.link_key(
-            network_info.tc_link_key.partner_ieee,
+        network_info.tc_link_key.key = await self._api.get_link_key()
+        network_info.tc_link_key.partner_ieee = (
+            await self._api.get_trust_center_address()
         )
-        network_info.tc_link_key.key = link_key.key
 
-        security_mode = await self._api.security_mode()
+        security_mode = await self._api.get_security_mode()
 
         if security_mode == SecurityMode.NO_SECURITY:
             network_info.security_level = 0x00
-        elif security_mode == SecurityMode.ONLY_TCLK:
+        elif security_mode == SecurityMode.PRECONFIGURED_NETWORK_KEY:
             network_info.security_level = 0x05
         else:
             LOGGER.warning("Unsupported security mode %r", security_mode)
@@ -301,45 +238,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def force_remove(self, dev):
         """Forcibly remove device from NCP."""
 
-    async def energy_scan(
-        self, channels: t.Channels.ALL_CHANNELS, duration_exp: int, count: int
-    ) -> dict[int, float]:
-        results = await super().energy_scan(
-            channels=channels, duration_exp=duration_exp, count=count
-        )
-
-        return {c: v * 3 for c, v in results.items()}
-
-        for i in range(ENERGY_SCAN_ATTEMPTS):
-            try:
-                rsp = await self._device.zdo.Mgmt_NWK_Update_req(
-                    zigpy.zdo.types.NwkUpdate(
-                        ScanChannels=channels,
-                        ScanDuration=duration_exp,
-                        ScanCount=count,
-                    )
-                )
-                break
-            except (asyncio.TimeoutError, zigpy.exceptions.DeliveryError):
-                if i == ENERGY_SCAN_ATTEMPTS - 1:
-                    raise
-
-                continue
-
-        _, scanned_channels, _, _, energy_values = rsp
-        return dict(zip(scanned_channels, energy_values))
-
     async def _move_network_to_channel(
         self, new_channel: int, new_nwk_update_id: int
     ) -> None:
         """Move device to a new channel."""
-        channel_mask = zigpy.types.Channels.from_channel_list([new_channel])
-        await self._api.set_channel_mask(channel_mask)
-        await self._api.set_nwk_update_id(new_nwk_update_id)
-
-        await self._change_network_state(NetworkState.OFFLINE)
-        await asyncio.sleep(CHANGE_NETWORK_STATE_DELAY)
-        await self._change_network_state(NetworkState.CONNECTED)
+        raise NotImplementedError()
 
     async def add_endpoint(self, descriptor: zdo_t.SimpleDescriptor) -> None:
         """Register a new endpoint on the device."""
@@ -393,13 +296,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if packet.source_route is not None:
             force_relays = packet.source_route
 
-        tx_options = t.ZnspTransmitOptions.NONE
+        tx_options = espzb_t.ZnspTransmitOptions.NONE
 
         if zigpy.types.TransmitOptions.ACK in packet.tx_options:
-            tx_options |= t.ZnspTransmitOptions.ACK_ENABLED
+            tx_options |= espzb_t.ZnspTransmitOptions.ACK_ENABLED
 
         if zigpy.types.TransmitOptions.APS_Encryption in packet.tx_options:
-            tx_options |= t.ZnspTransmitOptions.SECURITY_ENABLED
+            tx_options |= espzb_t.ZnspTransmitOptions.SECURITY_ENABLED
 
         async with self._limit_concurrency():
             await self._api.aps_data_request(
@@ -421,105 +324,3 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def permit_ncp(self, time_s=60):
         assert 0 <= time_s <= 254
         await self._api.set_permit_join(time_s)
-
-    async def restore_neighbours(self) -> None:
-        """Restore children."""
-        coord = self.get_device(ieee=self.state.node_info.ieee)
-
-        for neighbor in self.topology.neighbors[coord.ieee]:
-            try:
-                device = self.get_device(ieee=neighbor.ieee)
-            except KeyError:
-                continue
-
-            descr = device.node_desc
-            LOGGER.debug(
-                "device: 0x%04x - %s %s, FFD=%s, Rx_on_when_idle=%s",
-                device.nwk,
-                device.manufacturer,
-                device.model,
-                descr.is_full_function_device if descr is not None else None,
-                descr.is_receiver_on_when_idle if descr is not None else None,
-            )
-            if (
-                descr is None
-                or descr.is_full_function_device
-                or descr.is_receiver_on_when_idle
-            ):
-                continue
-
-            LOGGER.debug("Restoring %s as direct child", device)
-
-            try:
-                await self._api.add_neighbour(
-                    nwk=device.nwk,
-                    ieee=device.ieee,
-                    mac_capability_flags=descr.mac_capability_flags,
-                )
-            except zigpy_espzb.exception.CommandError as ex:
-                assert ex.status == Status.FAILURE
-                LOGGER.debug("Failed to add device to neighbor table: %s", ex)
-
-    async def _delayed_neighbour_scan(self) -> None:
-        """Scan coordinator's neighbours."""
-        await asyncio.sleep(DELAY_NEIGHBOUR_SCAN_S)
-        coord = self.get_device(ieee=self.state.node_info.ieee)
-        await self.topology.scan(devices=[coord])
-
-
-class ZnspDevice(zigpy.device.Device):
-    """Zigpy Device representing Coordinator."""
-
-    def __init__(self, model: str, *args):
-        """Initialize instance."""
-
-        super().__init__(*args)
-        self._model = model
-
-    async def add_to_group(self, grp_id: int, name: str = None) -> None:
-        group = self.application.groups.add_group(grp_id, name)
-
-        for epid in self.endpoints:
-            if not epid:
-                continue  # skip ZDO
-            group.add_member(self.endpoints[epid])
-        return [0]
-
-    async def remove_from_group(self, grp_id: int) -> None:
-        for epid in self.endpoints:
-            if not epid:
-                continue  # skip ZDO
-            self.application.groups[grp_id].remove_member(self.endpoints[epid])
-        return [0]
-
-    @property
-    def manufacturer(self):
-        return "Espressif Systems"
-
-    @property
-    def model(self):
-        return self._model
-
-    @classmethod
-    async def new(cls, application, ieee, nwk, model: str):
-        """Create or replace zigpy device."""
-        dev = cls(model, application, ieee, nwk)
-
-        if ieee in application.devices:
-            from_dev = application.get_device(ieee=ieee)
-            dev.status = from_dev.status
-            dev.node_desc = from_dev.node_desc
-            for ep_id, from_ep in from_dev.endpoints.items():
-                if not ep_id:
-                    continue  # Skip ZDO
-                ep = dev.add_endpoint(ep_id)
-                ep.profile_id = from_ep.profile_id
-                ep.device_type = from_ep.device_type
-                ep.status = from_ep.status
-                ep.in_clusters = from_ep.in_clusters
-                ep.out_clusters = from_ep.out_clusters
-        else:
-            application.devices[ieee] = dev
-            await dev.initialize()
-
-        return dev

--- a/zigpy_espzb/zigbee/application.py
+++ b/zigpy_espzb/zigbee/application.py
@@ -160,19 +160,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         await self._api.set_use_predefined_nwk_panid(True)
         await self._api.set_nwk_panid(network_info.pan_id)
-
-        # TODO: Why does setting the extended PAN ID trigger a crash?
-        #   Unknown command received: Command(
-        #     version=0,
-        #     frame_type=<FrameType.Response: 1>,
-        #     reserved=0,
-        #     command_id=<CommandId.undefined_0xffff: 65535>,
-        #     seq=123,
-        #     length=1,
-        #     payload=b'\x02'
-        #   )
-
-        # await self._api.set_nwk_extended_panid(network_info.extended_pan_id)
+        await self._api.set_nwk_extended_panid(network_info.extended_pan_id)
         await self._api.set_nwk_update_id(network_info.nwk_update_id)
         await self._api.set_network_key(network_info.network_key.key)
         await self._api.set_nwk_frame_counter(network_info.network_key.tx_counter)

--- a/zigpy_espzb/zigbee/application.py
+++ b/zigpy_espzb/zigbee/application.py
@@ -143,10 +143,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             raise FormationFailure("Network formation refused.")
 
     async def reset_network_info(self):
-        await self._api.leave_network()
+        await self._api.factory_reset()
 
     async def write_network_info(self, *, network_info, node_info):
-        await self._api.system_factory()
+        await self._api.factory_reset()
         await self._api.network_init()
         await self._api.form_network(role=DeviceType.COORDINATOR)
         # await self._api.start(autostart=False)
@@ -202,6 +202,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._api.start(autostart=True)
 
     async def load_network_info(self, *, load_devices=False):
+        channel = await self._api.get_current_channel()
+
+        if not 11 <= channel <= 26:
+            raise NetworkNotFormed(f"Channel is invalid: {channel}")
+
         network_info = self.state.network_info
         node_info = self.state.node_info
 

--- a/zigpy_espzb/zigbee/application.py
+++ b/zigpy_espzb/zigbee/application.py
@@ -146,7 +146,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._api.leave_network()
 
     async def write_network_info(self, *, network_info, node_info):
-        await self._api.reset()
+        await self._api.system_factory()
         await self._api.network_init()
         await self._api.form_network(role=DeviceType.COORDINATOR)
         # await self._api.start(autostart=False)
@@ -216,8 +216,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         node_info.ieee = await self._api.get_mac_address()
 
         # TODO: implement firmware commands to read the board name, manufacturer
-        node_info.manufacturer = "Espressif Systems"
-        node_info.model = "ESP32H2"
+        node_info.manufacturer = await self._api.system_manufacturer()
+        node_info.model = await self._api.system_model()
 
         # TODO: implement firmware command to read out the firmware version and build ID
         node_info.version = f"{int(self._api.firmware_version):#010x}"

--- a/zigpy_espzb/zigbee/application.py
+++ b/zigpy_espzb/zigbee/application.py
@@ -25,8 +25,13 @@ import zigpy.types as t
 import zigpy.util
 import zigpy.zdo.types as zdo_t
 
-from zigpy_espzb.api import DeviceType, NetworkState, SecurityMode, Znsp
-import zigpy_espzb.types as espzb_t
+from zigpy_espzb.api import Znsp
+from zigpy_espzb.types import (
+    DeviceType,
+    NetworkState,
+    SecurityMode,
+    ZnspTransmitOptions,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -307,13 +312,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if packet.source_route is not None:
             force_relays = packet.source_route
 
-        tx_options = espzb_t.ZnspTransmitOptions.NONE
+        tx_options = ZnspTransmitOptions.NONE
 
         if zigpy.types.TransmitOptions.ACK in packet.tx_options:
-            tx_options |= espzb_t.ZnspTransmitOptions.ACK_ENABLED
+            tx_options |= ZnspTransmitOptions.ACK_ENABLED
 
         if zigpy.types.TransmitOptions.APS_Encryption in packet.tx_options:
-            tx_options |= espzb_t.ZnspTransmitOptions.SECURITY_ENABLED
+            tx_options |= ZnspTransmitOptions.SECURITY_ENABLED
 
         async with self._limit_concurrency():
             await self._api.aps_data_request(

--- a/zigpy_espzb/zigbee/application.py
+++ b/zigpy_espzb/zigbee/application.py
@@ -187,6 +187,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._api.set_channel(network_info.channel)
 
         # TODO: Network settings do not persist. How do you write them?
+        await self._api.start(autostart=True)
+
         await self._api.reset()
         await self._api.network_init()
         await self._api.form_network(role=DeviceType.COORDINATOR)

--- a/zigpy_espzb/zigbee/application.py
+++ b/zigpy_espzb/zigbee/application.py
@@ -52,7 +52,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     def __init__(self, config: dict[str, Any]):
         """Initialize instance."""
 
-        super().__init__(config=zigpy.config.ZIGPY_SCHEMA(config))
+        super().__init__(config=config)
         self._api = None
 
         self._pending = zigpy.util.Requests()

--- a/zigpy_espzb/zigbee/application.py
+++ b/zigpy_espzb/zigbee/application.py
@@ -329,7 +329,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if t.TransmitOptions.APS_Encryption in packet.tx_options:
             tx_options |= TransmitOptions.SECURITY_ENABLED
 
-        async with self._limit_concurrency():
+        async with self._limit_concurrency(priority=packet.priority):
             await self._api.aps_data_request(
                 dst_addr=dst_addr,
                 dst_ep=packet.dst_ep,

--- a/zigpy_espzb/zigbee/application.py
+++ b/zigpy_espzb/zigbee/application.py
@@ -75,7 +75,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         # TODO: Most commands fail if the network is not formed. Why?
         await api.network_init()
-        await api.form_network(role=DeviceType.COORDINATOR)
         await api.start(autostart=False)
 
         self._api = api
@@ -89,8 +88,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         raise NotImplementedError()
 
     async def start_network(self):
-        await self._api.start(autostart=True)
-
         await self.load_network_info(load_devices=False)
         await self.register_endpoints()
 
@@ -112,6 +109,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         ep1.status = zigpy.endpoint.Status.ZDO_INIT
         ep2 = coordinator.add_endpoint(2)
         ep2.status = zigpy.endpoint.Status.ZDO_INIT
+
+        await self._api.form_network(role=DeviceType.COORDINATOR)
 
     async def _change_network_state(
         self,
@@ -148,8 +147,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def write_network_info(self, *, network_info, node_info):
         await self._api.factory_reset()
         await self._api.network_init()
-        await self._api.form_network(role=DeviceType.COORDINATOR)
-        # await self._api.start(autostart=False)
+        await self._api.start(autostart=False)
 
         role = {
             zdo_t.LogicalType.Coordinator: DeviceType.COORDINATOR,
@@ -192,14 +190,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             await self._api.set_security_mode(SecurityMode.PRECONFIGURED_NETWORK_KEY)
 
         await self._api.set_channel(network_info.channel)
-
-        # TODO: Network settings do not persist. How do you write them?
-        await self._api.start(autostart=True)
-
-        await self._api.reset()
-        await self._api.network_init()
-        await self._api.form_network(role=DeviceType.COORDINATOR)
-        await self._api.start(autostart=True)
 
     async def load_network_info(self, *, load_devices=False):
         channel = await self._api.get_current_channel()


### PR DESCRIPTION
This is a fairly large PR but until the radio library is actually functional I don't see a need to split it up.

I've made a few changes:
1. Adjusted the command serialization/parsing to work with the device's actual serial protocol instead of modifying the deCONZ protocol.
2. Renamed commands to more closely match what is in the SDK.
3. Renamed all getter API functions to use a `get_` prefix and setters to use `set_`.

At the moment, a few things do not work:

1. Radio startup does not work properly without adding fake endpoint objects because endpoint registration doesn't appear to be functional. The endpoints are registered but the coordinator does not respond to the loopback `Active_EP_req` with anything other than `[242, 242]` (also a bug?).
2. Restoring a backup crashes if `set_nwk_extended_panid` is called. If this call is removed, backup restoration "works" but no new settings are actually written.
3. `permit` similarly doesn't work and crashes with the same error as above.
4. There are no firmware commands to report the current firmware version, board name/model, or manufacturer name.
5. There is no way to reset the firmware into a known state. I'm intentionally crashing it to do so, but this isn't a very good way.

I believe that many of these issues stem from the network startup/shutdown/settings writing sequence being unclear. I wasn't able to find anything in the documentation about forming a new network with specific settings, especially with the radio already running.

For the library to be functional with ZHA, the following need to work and they are what I am currently trying to fix:

```bash
# Leave the current network and erase all settings
zigpy -vvv radio --baudrate 115200 znsp /dev/cu.usbserial-A94TYUSB reset

# Form a temporary network, perform an energy scan to find a good channel, then use the settings provided by zigpy
zigpy -vvv radio --baudrate 115200 znsp /dev/cu.usbserial-A94TYUSB form

# Dump the current network settings
zigpy -vvv radio --baudrate 115200 znsp /dev/cu.usbserial-A94TYUSB backup -z > backup.json

# Form a new network with random settings
zigpy -vvv radio --baudrate 115200 znsp /dev/cu.usbserial-A94TYUSB form

# Restore the old network settings
zigpy -vvv radio --baudrate 115200 znsp /dev/cu.usbserial-A94TYUSB restore backup.json

# Dump the settings again
zigpy -vvv radio --baudrate 115200 znsp /dev/cu.usbserial-A94TYUSB backup -z > backup2.json

# They should be identical except for the frame counter increasing by 5000 and the backup timestamp changing
diff backup.json backup2.json

# Energy scanning should work
zigpy -vvv radio --baudrate 115200 znsp /dev/cu.usbserial-A94TYUSB energy-scan

# And finally, new devices can join the network and be interviewed by zigpy
zigpy -vvv radio --baudrate 115200 znsp /dev/cu.usbserial-A94TYUSB permit
```

Could you explain a little more the process to read/write network settings like I have above? The `write_network_info` function should be pretty simple at this point so let me know what should be changed to get it working. I've added `# TODO` comments throughout the library in places where I ran into trouble.

Let me know if you have any questions!